### PR TITLE
ci: fix timing-out macOS test job (real Triton-wheel cache + 120m timeout + Node-24 actions)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: '3.12'
 
@@ -24,18 +24,21 @@ jobs:
 
   test:
     runs-on: macos-14  # M1 Apple Silicon with Metal GPU
-    timeout-minutes: 60  # first run builds Triton from source (~20-30 min); cached afterward
+    # Triton ships no macOS wheels, so we build it from source. A cold build is
+    # ~1 h on this runner; the wheel is then cached by Triton's commit, so all
+    # subsequent runs at the same Triton main skip the build. 120 min gives the
+    # cold build headroom (the old 60 min cap was what cancelled the run).
+    timeout-minutes: 120
     strategy:
       matrix:
         python-version: ['3.10', '3.12']
 
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'  # reuse the built Triton wheel across runs (avoids rebuilding)
 
       - name: Install dependencies
         run: |
@@ -45,12 +48,31 @@ jobs:
           # Metal entirely, so the "GPU" tests never actually ran on the GPU.
           pip install torch
 
-      - name: Install Triton (built from source — Triton publishes no macOS wheels)
+      - name: Resolve Triton's current main commit
+        id: triton
+        run: echo "sha=$(git ls-remote https://github.com/triton-lang/triton.git HEAD | cut -f1)" >> "$GITHUB_OUTPUT"
+
+      # Cache the BUILT wheel, keyed on Triton's current main commit + py + os.
+      # This is the piece that was broken before: `cache: pip` kept failing to
+      # deserialize, so every run rebuilt from scratch and blew the timeout.
+      - name: Cache the built Triton wheel
+        id: triton-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/triton-wheels
+          key: triton-wheel-${{ runner.os }}-py${{ matrix.python-version }}-${{ steps.triton.outputs.sha }}
+
+      - name: Build the Triton wheel (cache miss only — Triton publishes no macOS wheels)
+        if: steps.triton-cache.outputs.cache-hit != 'true'
         run: |
           pip install ninja cmake wheel
-          pip install -U git+https://github.com/triton-lang/triton.git
-        # Deliberately NOT continue-on-error: a failed Triton install must fail loudly here,
+          pip wheel "git+https://github.com/triton-lang/triton.git@${{ steps.triton.outputs.sha }}" \
+            --no-deps -w ~/triton-wheels
+        # Deliberately NOT continue-on-error: a failed Triton build must fail loudly here,
         # not be masked into a green step that then hard-errors every test on `import triton`.
+
+      - name: Install Triton from the (cached or freshly built) wheel
+        run: pip install ~/triton-wheels/triton-*.whl
 
       - name: Install test dependencies
         run: pip install transformers torchvision
@@ -81,7 +103,7 @@ jobs:
         run: python scripts/check_upstream_regression.py --report-dir reports/
 
       - name: Upload test reports
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         if: always()
         with:
           name: test-reports-py${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,10 @@ jobs:
 
       - name: Resolve Triton's current main commit
         id: triton
-        run: echo "sha=$(git ls-remote https://github.com/triton-lang/triton.git HEAD | cut -f1)" >> "$GITHUB_OUTPUT"
+        run: |
+          sha="$(git ls-remote https://github.com/triton-lang/triton.git HEAD | head -n1 | cut -f1)"
+          echo "Triton main commit: $sha"
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
 
       # Cache the BUILT wheel, keyed on Triton's current main commit + py + os.
       # This is the piece that was broken before: `cache: pip` kept failing to


### PR DESCRIPTION
## Problem
The `test` job (macOS, py 3.10 + 3.12) was being **cancelled at the 60-min cap** (`1h0m42s`), so CI never went green. Root causes:

1. **Cold build no longer fits 60 min.** Triton ships no macOS wheels, so the job builds it from source (`git+…/triton.git`). The comment assumed ~20–30 min; it now runs past the 60-min cap.
2. **The wheel cache was broken.** `cache: 'pip'` logged *"Cache entry deserialization failed, entry ignored"* on every run → full rebuild each time. And `git+main` unpinned busts any cache whenever upstream Triton moves.

(The `lint` job was already green — this is the only thing between us and green CI.)

## Fix (keeps tracking upstream Triton main — the `upstream-regression` steps want that)
- **Cache the *built wheel*** via `actions/cache`, keyed on Triton's resolved `main` commit + os + py. Most runs restore the wheel and skip the build; only a new Triton main commit triggers a rebuild.
- **Build with `pip wheel … --no-deps`** into `~/triton-wheels` *on cache miss only*; install from the wheel either way.
- **`timeout-minutes` 60 → 120** so the cold build fits.
- **Bump pinned actions to Node-24 majors** (checkout v7, setup-python v6, upload-artifact v7, cache v6) — clears the Node-20 deprecation warnings.

## Expectations
- **First run after merge is a cold ~1h build** that populates the cache.
- Subsequent runs at the same Triton main are fast (restore wheel → straight to tests).
- Trade-off of tracking main: if a given Triton main commit fails to build, CI goes red until upstream fixes (or we pin) — by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI reliability by updating workflow action versions.
  * Extended the macOS test timeout to better handle slower builds.
  * Added smarter caching for macOS builds to reduce repeated setup time and speed up future test runs.
  * Updated artifact upload handling for test reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->