### PR TITLE
codegen: a 1-D store after a 2-D axis=1 reduce dropped the program offset

### DIFF
--- a/triton_msl/codegen/generic_lowerer.py
+++ b/triton_msl/codegen/generic_lowerer.py
@@ -3485,6 +3485,7 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
             )
 
         ptr_info = self.env_is_ptr.get(ptr_id)
+        offsets_from_pointer_arith = ptr_info is not None
         if ptr_info:
             base_ptr, offsets = ptr_info
         else:
@@ -3532,12 +3533,24 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
                 guard = f"{lid} < {store_1d_guard}u"
             else:
                 # After a 2D reduce (axis=1), the result is per-row and the
-                # broadcast uses lid / N (blocked). Fix: use lid / N as the
-                # store index and select one thread per row block.
+                # broadcast uses lid / N (blocked), so ONE thread per row must
+                # be selected to store. That selection is the guard.
+                #
+                # The store INDEX is a separate question. When the pointer came
+                # from pointer arithmetic the lowerer has already built the real
+                # address expression -- for a kernel storing at
+                # `out + (pid * BLOCK + arange(BLOCK))` that expression carries
+                # the program's own offset. Overwriting it with `lid / N`
+                # discards that, and every threadgroup then writes the same
+                # slot: a grid of M programs leaves one row written and M-1
+                # rows untouched, with no error and no refusal. Only when there
+                # was no pointer arithmetic -- the offset having defaulted to
+                # `lid` -- must the index be derived from the thread id.
                 shape = self._effective_2d_shape
                 if shape and len(shape) >= 2 and store_1d_guard == shape[0] and shape[1] > 0:
                     N = shape[1]
-                    offsets = f"({lid} / {N}u)"
+                    if not offsets_from_pointer_arith:
+                        offsets = f"({lid} / {N}u)"
                     guard = f"{lid} % {N}u == 0u && {lid} / {N}u < {store_1d_guard}u"
                 else:
                     guard = f"{lid} < {store_1d_guard}u"


### PR DESCRIPTION
### Symptom

A kernel that reduces a 2-D tile along axis 1 and stores the 1-D result writes
**one row and leaves the rest untouched**. No error, no refusal, no warning —
the output has the right shape and dtype, and every element but one row is
whatever the buffer held before.

### Minimal reproducer

```python
@triton.jit
def row_sum(X, Y, N: tl.constexpr, BLOCK: tl.constexpr):
    pid = tl.program_id(0)
    cols = tl.arange(0, BLOCK)
    x = tl.load(X + pid * N + cols, mask=cols < N, other=0.0)
    tl.store(Y + pid, tl.sum(x, axis=0))

# grid = (M,)  -> every program stores to Y + pid
```

With `M` programs, all `M` write the same slot: `Y[0]` ends up holding one
program's result and `Y[1..M-1]` are never written.

### Cause

In the 1-D store path the store index is overwritten with the intra-tile row
index `lid / N`, discarding the address the lowerer had already built from the
pointer arithmetic. For `Y + pid` that address *is* `pid`, so replacing it
with `lid / N` — which is 0 for every thread of a single-row tile — sends
every program to slot 0.

### Fix

The intra-tile index is still what elects one storing thread per row, so the
guard is unchanged. The store index now keeps the computed offset whenever the
pointer came from pointer arithmetic, and falls back to `lid / N` only when the
offset defaulted to `lid` and there is nothing else to use.

### Test suite

Before: the added test fails, writing row 0 only.
After: it passes.
The rest of the suite is unchanged — this touches one branch of the 1-D store
path and nothing else reaches it.

---

*Seven more fixes to this backend are ready and will follow as separate pull
requests, each independent: a matmul template that writes only the first
column tile, a flash-attention detector that drops a causal mask, and five
smaller ones. Happy to send them in whatever order suits you, or to hold them
until this one has been looked at.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected handling of row-based operations when offsets are calculated through explicit pointer arithmetic.
  - Preserved computed offsets in these cases while maintaining the one-thread-per-row behavior.
  - Improved indexing accuracy for one-dimensional stores represented within two-dimensional operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->