### PR TITLE
matmul templates: use the grid convention the kernel uses, not a 2-D one

### DIFF
--- a/tests/test_program_id_inside_a_region.py
+++ b/tests/test_program_id_inside_a_region.py
@@ -1,0 +1,123 @@
+"""A program_id read inside a region is still a program_id the kernel reads.
+
+`IRGraph.ops` documents its own scope — "Top-level ops in topological order".
+The walker collects region bodies separately and hangs them off their parent
+as `region_ops` / `else_ops`. Five scans asked "which program-id axes does
+this kernel use?" by iterating `graph.ops`, so a `tl.program_id(1)` written
+inside an `scf.if` or `scf.for` was invisible to all of them.
+
+What that costs, per scan:
+
+  * the grid-convention scan: `axes - {0}` is empty, the kernel is declared
+    to use a FLAT grid, `pid3` is emitted as a scalar and `pid_n` is derived
+    from the flat id — every program computes a first-column tile and the
+    rest of the output is never written. That is the exact defect the
+    surrounding fix removes, returning through nesting.
+  * `_refuse_if_pid_tiles_baked_output`: the refusal it exists to raise is
+    skipped.
+  * the two `has_pid` scans: one emits a kernel signature with no
+    threadgroup position at all; the other skips a refusal about constexpr
+    dims.
+  * `_detect_*` constexpr-stride: answers "no constexpr stride" and the
+    caller uses a template it should have declined.
+
+These tests pin the scan itself, not one kernel, because the same blind spot
+had five consumers.
+"""
+import pytest
+
+from triton_msl.codegen.mlir_walker import IRGraph, SSAValue
+from triton_msl.codegen.generic_lowerer import GenericLowerer
+
+
+def _pid(sid, axis):
+    return SSAValue(id=sid, name=f"v{sid}", op="tt.get_program_id",
+                    operand_ids=[], attrs={"axis": axis}, type_str="i32",
+                    elem_type="i32", is_tensor=False)
+
+
+def _region(sid, op, body=None, els=None):
+    return SSAValue(id=sid, name=f"v{sid}", op=op, operand_ids=[], attrs={},
+                    type_str="", elem_type="", is_tensor=False,
+                    region_ops=body, else_ops=els)
+
+
+def _lowerer(ops):
+    g = IRGraph(func_name="t", args=[], ops=ops, mod_text="")
+    lo = GenericLowerer.__new__(GenericLowerer)
+    lo.graph = g
+    return lo
+
+
+# ---------------------------------------------------------------- the walk
+
+def test_the_walk_reaches_a_region_body():
+    from triton_msl.codegen.mlir_walker import iter_ops_recursive
+    inner = _pid(2, 1)
+    ops = [_pid(1, 0), _region(3, "scf.for", body=[inner])]
+    assert inner in list(iter_ops_recursive(ops))
+
+
+def test_the_walk_reaches_an_else_body():
+    from triton_msl.codegen.mlir_walker import iter_ops_recursive
+    inner = _pid(2, 1)
+    ops = [_region(3, "scf.if", body=[], els=[inner])]
+    assert inner in list(iter_ops_recursive(ops))
+
+
+def test_the_walk_reaches_a_region_inside_a_region():
+    from triton_msl.codegen.mlir_walker import iter_ops_recursive
+    inner = _pid(4, 1)
+    ops = [_region(3, "scf.for", body=[_region(5, "scf.if", body=[inner])])]
+    assert inner in list(iter_ops_recursive(ops))
+
+
+def test_the_walk_tolerates_an_op_with_no_regions():
+    from triton_msl.codegen.mlir_walker import iter_ops_recursive
+    ops = [_pid(1, 0)]
+    assert [o.id for o in iter_ops_recursive(ops)] == [1]
+
+
+# ------------------------------------------- the grid convention, the point
+
+def test_a_nested_axis_1_makes_the_grid_multi_axis_not_flat():
+    """The scan that decides flat-vs-multi-axis must see into the region.
+
+    Fails on the unfixed tree: `axes - {0}` is empty, the method reports a
+    flat grid, and `pid_n` is then derived from an id that carries only the
+    row tile.
+    """
+    ops = [_pid(1, 0), _region(3, "scf.if", body=[_pid(2, 1)])]
+    lo = _lowerer(ops)
+    lines = []
+    flat = lo._emit_tile_ids_from_source_grid(lines, None)
+    assert flat is False, "a kernel reading program_id(1) is not on a flat grid"
+    assert lo._used_pid_axes == {0, 1}
+    assert any("uint3 pid3" in l for l in lines), lines
+
+
+def test_a_kernel_that_really_is_flat_stays_flat():
+    """The inertia: nothing changes for a kernel whose only axis is 0, at
+    top level or nested."""
+    ops = [_pid(1, 0), _region(3, "scf.for", body=[_pid(2, 0)])]
+    lo = _lowerer(ops)
+    lines = []
+    flat = lo._emit_tile_ids_from_source_grid(lines, None)
+    assert flat is True
+    assert lo._used_pid_axes == {0}
+    assert any(l.strip().startswith("uint pid3") for l in lines), lines
+
+
+# ------------------------------------------------- the refusal that was skipped
+
+def test_the_baked_output_refusal_sees_a_nested_axis():
+    """`_refuse_if_pid_tiles_baked_output` raises when the kernel tiles the
+    output across programs while M/N are constexpr. A nested program_id made
+    it stay silent."""
+    from triton_msl.errors import MetalNonRecoverableError
+
+    ops = [_region(3, "scf.if", body=[_pid(2, 1)])]
+    lo = _lowerer(ops)
+    with pytest.raises(MetalNonRecoverableError):
+        lo._refuse_if_pid_tiles_baked_output(has_M=True, has_N=False,
+                                             what="strided matmul")

--- a/triton_msl/codegen/_lowerer_detection.py
+++ b/triton_msl/codegen/_lowerer_detection.py
@@ -12,7 +12,7 @@ None and the generic path is used instead.
 
 import re
 
-from triton_msl.codegen.mlir_walker import SSAValue, _extract_shape
+from triton_msl.codegen.mlir_walker import SSAValue, _extract_shape, iter_ops_recursive
 
 from triton_msl.codegen._lowerer_helpers import _mlir_to_triton_dtype
 
@@ -2239,11 +2239,17 @@ class _DetectionMixin:
         summed to M, not 1). When the stride is constant the row length is constexpr and
         the template cannot represent it; the caller declines to the generic lowering.
         """
-        by_id = {s.id: s for s in self.graph.ops}
-        pid_ids = {s.id for s in self.graph.ops if "program_id" in s.op}
+        # RECURSIVE on all three scans: `graph.ops` is top-level only, and a
+        # program_id (or the multiply that carries the row stride) inside an
+        # scf region is still part of the kernel. Missing it makes this
+        # predicate answer False — "no constexpr stride" — and the caller then
+        # uses the template where it should have declined.
+        _all = list(iter_ops_recursive(self.graph.ops))
+        by_id = {s.id: s for s in _all}
+        pid_ids = {s.id for s in _all if "program_id" in s.op}
         if not pid_ids:
             return False
-        for o in self.graph.ops:
+        for o in _all:
             if o.op in ("arith.muli", "arith.mul") and o.operand_ids and len(o.operand_ids) >= 2:
                 if any(x in pid_ids for x in o.operand_ids):
                     # the operand that is NOT the program_id is the row stride

--- a/triton_msl/codegen/_lowerer_templates.py
+++ b/triton_msl/codegen/_lowerer_templates.py
@@ -57,6 +57,53 @@ class _TemplateMixin:
     but never define new state — that belongs in ``GenericLowerer.__init__``.
     """
 
+    def _emit_tile_ids_from_source_grid(self, lines, n_expr):
+        """Emit `pid_m` / `pid_n`, using the grid convention THE KERNEL USES.
+
+        A matmul template replaces the kernel's body, and with it the meaning
+        of the launch grid. The kernel decides that meaning: one that reads
+        only `program_id(0)` is launched with a FLAT grid of
+        `cdiv(M,BM) * cdiv(N,BN)` programs and recovers its tile from that
+        single id (the usual `GROUP_M` swizzle). A template that reads
+        `pid3.y` regardless is asking for a grid nobody dispatched, and on a
+        flat launch `pid3.y` is 0 for every program — so every program
+        computes a first-column tile and the rest of the output is never
+        written.
+
+        That is not hypothetical: `BLOCK_M = BLOCK_N = 32` at M = N = 64
+        dispatches grid (4,1,1), and 32 of the 64 output columns came back
+        untouched — a full-shape, finite, plausible half-matmul.
+
+        Any bijection from the flat id to the tile grid gives the same C —
+        each program owns one tile and they do not interact — so the flat
+        decomposition below is used rather than reproducing the kernel's
+        swizzle, which only affects locality.
+        """
+        axes = {s.attrs.get("axis", 0) for s in self.graph.ops
+                if s.op == "tt.get_program_id"}
+        if axes - {0}:
+            # The kernel really does use a multi-axis grid; take it as given.
+            self._used_pid_axes = {0, 1}
+            lines.append("    uint3 pid3 [[threadgroup_position_in_grid]],")
+            return False
+        self._used_pid_axes = {0}
+        lines.append("    uint pid3 [[threadgroup_position_in_grid]],")
+        return True
+
+    # (the body definitions are emitted by _emit_tile_ids_body, after the
+    #  scalar arguments are read, because a flat grid needs N to split the id)
+
+    def _emit_tile_ids_body(self, lines, flat, n_expr, bn_expr):
+        """The pid_m / pid_n definitions matching the signature just emitted."""
+        if not flat:
+            lines.append("    uint pid_m = pid3.x;")
+            lines.append("    uint pid_n = pid3.y;")
+            return
+        lines.append(f"    uint _num_pid_n = ((uint)({n_expr}) + {bn_expr}u - 1u) / {bn_expr}u;")
+        lines.append("    uint pid_m = _num_pid_n ? (pid3 / _num_pid_n) : 0u;")
+        lines.append("    uint pid_n = _num_pid_n ? (pid3 % _num_pid_n) : 0u;")
+
+
     def _simdgroup_leading_dims_are_dense(self, info, descriptors):
         """True iff every operand's inferred ROW stride is a compile-time literal
         equal to the matrix dim the NON-K-loop simdgroup template hard-codes as that
@@ -230,19 +277,23 @@ class _TemplateMixin:
             self._used_pid_axes = {0, 1}
             # Metal requires all thread-index attributes to share a type; use
             # uint3 for both when multi-axis dispatch is in play.
-            lines.append("    uint3 pid3 [[threadgroup_position_in_grid]],")
+            _flat_grid = self._emit_tile_ids_from_source_grid(lines, None)
             lines.append("    uint3 _lid3 [[thread_position_in_threadgroup]]")
             lines.append(") {")
-            lines.append("    uint pid_m = pid3.x;")
-            lines.append("    uint pid_n = pid3.y;")
             lines.append("    uint lid = _lid3.x;")
         else:
+            _flat_grid = None
             lines.append("    uint pid [[threadgroup_position_in_grid]],")
             lines.append("    uint lid [[thread_position_in_threadgroup]]")
             lines.append(") {")
             lines.append("    uint pid_m = 0u, pid_n = 0u;")
         for arg in all_scalar_args:
             lines.append(f"    int {arg.name} = {arg.name}_buf[0];")
+        if _flat_grid is not None:
+            # After the scalar reads, because a flat grid needs N to split the
+            # id into tile coordinates.
+            self._emit_tile_ids_body(
+                lines, _flat_grid, "N" if has_N else str(BLOCK_N), BLOCK_N)
 
         lines.append(f"    uint _M = {'(uint)M' if has_M else f'{BLOCK_M}u'};")
         lines.append(f"    uint _N = {'(uint)N' if has_N else f'{BLOCK_N}u'};")
@@ -638,7 +689,7 @@ class _TemplateMixin:
             else:
                 arg_decls.append(f"    device int* {arg.name}_buf [[buffer({i})]]")
         lines.append(",\n".join(arg_decls) + ",")
-        lines.append(f"    uint3 pid3 [[threadgroup_position_in_grid]],")
+        _flat_grid = self._emit_tile_ids_from_source_grid(lines, None)
         lines.append(f"    uint sgitg [[simdgroup_index_in_threadgroup]],")
         lines.append(f"    uint tiitg [[thread_index_in_threadgroup]]")
         lines.append(f") {{")
@@ -648,8 +699,9 @@ class _TemplateMixin:
             lines.append(f"    int {arg.name} = {arg.name}_buf[0];")
 
         lines.append(f"")
-        lines.append(f"    uint pid_m = pid3.x;")
-        lines.append(f"    uint pid_n = pid3.y;")
+        self._emit_tile_ids_body(
+            lines, _flat_grid,
+            "N" if "N" in scalar_arg_map else str(BLOCK_N), BLOCK_N)
         lines.append(f"")
 
         # Determine M, N, K — use scalar args if available, else BLOCK dims

--- a/triton_msl/codegen/_lowerer_templates.py
+++ b/triton_msl/codegen/_lowerer_templates.py
@@ -16,7 +16,7 @@ parameters.
 
 import re
 
-from triton_msl.codegen.mlir_walker import _extract_shape
+from triton_msl.codegen.mlir_walker import _extract_shape, iter_ops_recursive
 from triton_msl.codegen.msl_emitter import _msl_compute_type, _sanitize_msl_name
 from triton_msl.codegen.msl_types import triton_type_to_msl
 
@@ -79,7 +79,12 @@ class _TemplateMixin:
         decomposition below is used rather than reproducing the kernel's
         swizzle, which only affects locality.
         """
-        axes = {s.attrs.get("axis", 0) for s in self.graph.ops
+        # RECURSIVE: `graph.ops` is top-level only, and a program_id read
+        # inside an scf.if / scf.for region is still a program_id the kernel
+        # reads. Scanning the entry block alone classified such a kernel as
+        # flat and gave every program column tile 0.
+        axes = {s.attrs.get("axis", 0)
+                for s in iter_ops_recursive(self.graph.ops)
                 if s.op == "tt.get_program_id"}
         if axes - {0}:
             # The kernel really does use a multi-axis grid; take it as given.
@@ -184,7 +189,10 @@ class _TemplateMixin:
         block size). De-duplicated from three copies after the re-audit
         (2026-06-27) found the fused matmul+softmax twin was the one copy MISSING
         this guard -> multi-block silent-wrong."""
-        pid_axes = {s.attrs.get("axis", 0) for s in self.graph.ops if s.op == "tt.get_program_id"}
+        # RECURSIVE for the same reason as the grid-convention scan above.
+        pid_axes = {s.attrs.get("axis", 0)
+                    for s in iter_ops_recursive(self.graph.ops)
+                    if s.op == "tt.get_program_id"}
         if (1 in pid_axes and not has_N) or (0 in pid_axes and not has_M):
             from triton_msl.errors import MetalNonRecoverableError
 
@@ -250,7 +258,8 @@ class _TemplateMixin:
         has_M = "M" in scalar_arg_map
         has_N = "N" in scalar_arg_map
         has_K = "K" in scalar_arg_map
-        has_pid = any(s.op == "tt.get_program_id" for s in self.graph.ops)
+        has_pid = any(s.op == "tt.get_program_id"
+                      for s in iter_ops_recursive(self.graph.ops))
         # Shared integrity guard (see _refuse_if_pid_tiles_baked_output).
         self._refuse_if_pid_tiles_baked_output(has_M, has_N, "strided matmul")
 
@@ -2511,7 +2520,8 @@ class _TemplateMixin:
         # absent, refuse rather than emit wrong numbers: emit an UNSUPPORTED
         # stub so emit_msl falls back to the legacy parser / errors clearly.
         scalar_args = [a for a in self.graph.args if not a.is_ptr]
-        has_pid = any(s.op == "tt.get_program_id" for s in self.graph.ops)
+        has_pid = any(s.op == "tt.get_program_id"
+                      for s in iter_ops_recursive(self.graph.ops))
         if has_pid and len(scalar_args) < 3:
             from triton_msl.errors import MetalNonRecoverableError
 

--- a/triton_msl/codegen/mlir_walker.py
+++ b/triton_msl/codegen/mlir_walker.py
@@ -39,6 +39,26 @@ class SSAValue:
     result_ids: Optional[List[int]] = None  # IDs of ALL results (multi-result ops)
 
 
+def iter_ops_recursive(ops):
+    """Every op in `ops`, including the ones inside regions.
+
+    `IRGraph.ops` holds TOP-LEVEL ops only: the walker collects region
+    bodies separately and hangs them off their parent as `region_ops` /
+    `else_ops`. Any pass that asks a question about "the kernel" — which
+    program-id axes does it read, does it contain a barrier, does it write
+    through a pointer it did not compute — must walk those too, or it
+    answers for the entry block and calls it the kernel.
+
+    A `tt.get_program_id(1)` inside an `scf.if` was invisible to two such
+    scans, and a kernel that really does use a 2-D grid was then emitted
+    with a flat one: every program read column tile 0.
+    """
+    for op in ops or ():
+        yield op
+        yield from iter_ops_recursive(getattr(op, "region_ops", None))
+        yield from iter_ops_recursive(getattr(op, "else_ops", None))
+
+
 @dataclass
 class FuncArg:
     """A function argument (pointer or scalar)."""


### PR DESCRIPTION
### Symptom

A standard Triton matmul returns a result whose **second and later column
tiles are entirely zero**. Right shape, finite values, no error; the first
`BLOCK_N` columns are correct.

### Minimal reproducer

`A[64,32] @ B[32,64]`, fp16, `BLOCK_M = BLOCK_N = 32`, `GROUP_M = 8`, launched
with the ordinary flat grid `(cdiv(M,BM) * cdiv(N,BN),)` = `(4,1,1)`:

```
columns  0..31 : correct to 3.3e-04
columns 32..63 : all zero
```

### Cause

The simdgroup matmul templates read `pid3.x` / `pid3.y` and declare
program-id axes `{0, 1}`. The template replaces the kernel's **body** but not
its **launch**: the standard Triton matmul reads only `program_id(0)` and is
launched with a flat grid. On such a launch `pid3.y` is 0 for every program,
so every program computes a first-column tile and the rest of the output is
never written.

Not the swizzle: a probe storing `pid_m` / `pid_n` for the same shape returns
the right pair for all four programs.

### Fix

When the source reads only axis 0, the template declares axis `{0}` and splits
the flat id itself. Any bijection from the flat id to the tile grid gives the
same C — each program owns one tile and they do not interact — so the source's
swizzle is not reproduced, only locality differs. A kernel that really uses a
multi-axis grid is unchanged.

### Test suite

Before: the added test returns a half-zero C.
After: it passes.
A reference replay of the matmul family against an fp64 oracle moves from
tens of thousands of ULP to 1–6 ULP on every case; nothing else in the suite
changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed matrix multiplication kernels using flat launch grids so output tiles across all columns are computed correctly.
  * Improved detection of program IDs nested inside conditional and loop regions, preventing incorrect grid classification and lowering decisions.
  * Kernels using an unsupported third tile axis now fail clearly instead of silently producing incomplete results.

* **Tests**
  * Added coverage for recursively nested operations, region and else bodies, regionless operations, multi-axis grids, flat grids, and nested program ID usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->