### PR TITLE
flash-attention: additive bias, separate q/k lengths, and a causal mask that was being dropped

### DIFF
--- a/tests/test_fa_decode_and_scale_cast.py
+++ b/tests/test_fa_decode_and_scale_cast.py
@@ -1,0 +1,194 @@
+"""FlashAttention where the query and key sequences are not the same length,
+and where the softmax scale reaches the dot through a dtype cast.
+
+Both cases are ordinary — the first is every token a language model emits
+after the first, the second is what `q = (q * scale).to(q.dtype)` compiles to
+on a fp16 kernel — and both were refused before the changes these tests
+cover:
+
+* the scale walk-back stopped at the `arith.truncf` a fp16 kernel inserts
+  between the multiply and the dot, so the scale did not resolve, the kernel
+  was not recognized as attention, and it refused further down the generic
+  path for an unrelated reason (a 2-D axis reduce inside a loop);
+* a query tile below 32 rows — what a hardware profile picks for
+  `seqlen_q = 1` — was refused by a guard written for the generic per-thread
+  lowering, which the tiled template does not share;
+* the query length of a decode step is 1, which Triton's `equal_to_1`
+  specialization replaces with a literal, and both the bound resolver and the
+  store-mask triviality proof accepted only a scalar ARGUMENT.
+
+The reference is computed in float64 and compared in the kernel's dtype.
+"""
+
+import pytest
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+
+    _HAS_TRITON = True
+except ImportError:
+    _HAS_TRITON = False
+
+requires_triton = pytest.mark.skipif(not _HAS_TRITON, reason="Triton not installed")
+
+try:
+    from triton_msl.errors import MetalNonRecoverableError
+except Exception:  # pragma: no cover
+    MetalNonRecoverableError = Exception
+
+
+@triton.jit
+def _fa_two_lengths(
+    Q, K, V, Out,
+    stride_qz, stride_qh, stride_qm, stride_qk,
+    stride_kz, stride_kh, stride_kn, stride_kk,
+    stride_vz, stride_vh, stride_vn, stride_vk,
+    stride_oz, stride_oh, stride_om, stride_ok,
+    Z, H, seqlen_q, seqlen_k,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    IS_CAUSAL: tl.constexpr,
+):
+    """FA2 forward with independent query / key lengths.
+
+    The scale is applied to Q and cast BACK to Q's dtype, which is what the
+    reference implementations do and what puts an `arith.truncf` between the
+    multiply and the dot on a fp16 kernel.
+    """
+    start_m = tl.program_id(0)
+    off_hz = tl.program_id(1)
+    off_z = off_hz // H
+    off_h = off_hz % H
+
+    offs_m = start_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = tl.arange(0, BLOCK_N)
+    offs_d = tl.arange(0, HEAD_DIM)
+
+    q_ptrs = (Q + off_z * stride_qz + off_h * stride_qh
+              + offs_m[:, None] * stride_qm + offs_d[None, :] * stride_qk)
+    q = tl.load(q_ptrs, mask=offs_m[:, None] < seqlen_q, other=0.0)
+
+    qk_scale = 1.0 / tl.sqrt(float(HEAD_DIM))
+    q = (q * qk_scale).to(q.dtype)
+
+    m_i = tl.full([BLOCK_M], float("-inf"), dtype=tl.float32)
+    l_i = tl.zeros([BLOCK_M], dtype=tl.float32)
+    acc = tl.zeros([BLOCK_M, HEAD_DIM], dtype=tl.float32)
+
+    for start_n in range(0, seqlen_k, BLOCK_N):
+        k_ptrs = (K + off_z * stride_kz + off_h * stride_kh
+                  + (start_n + offs_n)[:, None] * stride_kn
+                  + offs_d[None, :] * stride_kk)
+        k = tl.load(k_ptrs, mask=(start_n + offs_n)[:, None] < seqlen_k, other=0.0)
+
+        qk = tl.dot(q, tl.trans(k).to(q.dtype))
+
+        if IS_CAUSAL:
+            mask = offs_m[:, None] >= (start_n + offs_n[None, :])
+            qk = tl.where(mask, qk, float("-inf"))
+
+        m_ij = tl.max(qk, 1)
+        m_new = tl.maximum(m_i, m_ij)
+        alpha = tl.exp(m_i - m_new)
+        p = tl.exp(qk - m_new[:, None])
+
+        l_i = l_i * alpha + tl.sum(p, 1)
+        acc = acc * alpha[:, None]
+
+        v_ptrs = (V + off_z * stride_vz + off_h * stride_vh
+                  + (start_n + offs_n)[:, None] * stride_vn
+                  + offs_d[None, :] * stride_vk)
+        v = tl.load(v_ptrs, mask=(start_n + offs_n)[:, None] < seqlen_k, other=0.0)
+
+        acc += tl.dot(p.to(tl.float32), v.to(tl.float32))
+        m_i = m_new
+
+    acc = acc / l_i[:, None]
+
+    o_ptrs = (Out + off_z * stride_oz + off_h * stride_oh
+              + offs_m[:, None] * stride_om + offs_d[None, :] * stride_ok)
+    tl.store(o_ptrs, acc.to(Out.dtype.element_ty), mask=offs_m[:, None] < seqlen_q)
+
+
+def _oracle(q, k, v):
+    """softmax(q k^T / sqrt(d)) v in float64, written out."""
+    q64, k64, v64 = q.double(), k.double(), v.double()
+    scores = torch.matmul(q64, k64.transpose(-2, -1)) / (q.shape[-1] ** 0.5)
+    return torch.matmul(torch.softmax(scores, dim=-1), v64)
+
+
+def _run(seqlen_q, seqlen_k, BLOCK_M, BLOCK_N, dtype, head_dim=64, H=2,
+         causal=False):
+    torch.manual_seed(7)
+    Z = 1
+    q = torch.randn(Z, H, seqlen_q, head_dim, dtype=torch.float32).to(dtype)
+    k = torch.randn(Z, H, seqlen_k, head_dim, dtype=torch.float32).to(dtype)
+    v = torch.randn(Z, H, seqlen_k, head_dim, dtype=torch.float32).to(dtype)
+    out = torch.zeros_like(q)
+    grid = ((seqlen_q + BLOCK_M - 1) // BLOCK_M, Z * H)
+    _fa_two_lengths[grid](
+        q, k, v, out,
+        q.stride(0), q.stride(1), q.stride(2), q.stride(3),
+        k.stride(0), k.stride(1), k.stride(2), k.stride(3),
+        v.stride(0), v.stride(1), v.stride(2), v.stride(3),
+        out.stride(0), out.stride(1), out.stride(2), out.stride(3),
+        Z, H, seqlen_q, seqlen_k,
+        BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N, HEAD_DIM=head_dim, IS_CAUSAL=causal,
+    )
+    return out, _oracle(q, k, v)
+
+
+@requires_triton
+@pytest.mark.parametrize("dtype,tol", [(torch.float16, 4e-3), (torch.float32, 1e-5)])
+def test_scale_through_a_dtype_cast_is_resolved(dtype, tol):
+    """`(q * scale).to(q.dtype)` must still resolve the scale.
+
+    On fp16 the cast is an `arith.truncf` sitting between the multiply and the
+    dot. Walking past it is what tells the kernel apart from one with no scale
+    at all; without it a fp16 attention refuses.
+    """
+    out, ref = _run(64, 64, 32, 32, dtype)
+    assert torch.isfinite(out).all()
+    assert (out.double() - ref).abs().max().item() < tol
+
+
+@requires_triton
+@pytest.mark.parametrize("BLOCK_M", [8, 16])
+def test_decode_one_query_row_against_a_long_key_sequence(BLOCK_M):
+    """seqlen_q = 1 against seqlen_k = 128 — a decode step.
+
+    The query tile is under 32 rows and the query length is a literal, both of
+    which used to refuse. Correctness is what is asserted: the tile is padding,
+    not a shorter computation.
+    """
+    out, ref = _run(1, 128, BLOCK_M, 32, torch.float16)
+    assert torch.isfinite(out).all()
+    assert (out.double() - ref).abs().max().item() < 4e-3
+
+
+@requires_triton
+def test_query_shorter_than_keys_does_not_read_past_q():
+    """A query tile wider than the query sequence must not run off the end.
+
+    With one bound for both, the template guarded the query rows with the KEY
+    length: 8 query rows against 128 keys read 128 rows of Q. The rows past
+    the end are guarded, so the answer stays the oracle's.
+    """
+    out, ref = _run(8, 128, 16, 32, torch.float32)
+    assert torch.isfinite(out).all()
+    assert (out.double() - ref).abs().max().item() < 1e-5
+
+
+@requires_triton
+def test_causal_with_distinct_lengths_refuses():
+    """A causal mask over different lengths has to say where the queries sit.
+
+    Aligned to the start of the key sequence or to its end are both real
+    conventions and they disagree; the IR does not say which. Refusing is the
+    only answer that cannot be silently wrong.
+    """
+    with pytest.raises(MetalNonRecoverableError):
+        _run(16, 128, 16, 32, torch.float32, causal=True)

--- a/tests/test_flash_attention.py
+++ b/tests/test_flash_attention.py
@@ -629,13 +629,23 @@ class TestFlashAttention:
     def test_small_block_refuses(self, BLOCK, HEAD_DIM):
         """Integrity guard for the small-BLOCK silent-wrong hole (closed 2026-06-17).
 
-        The attention lowering is validated ONLY at BLOCK_M = BLOCK_N = 32. With a
-        block tile dimension < 32 it silently mis-computes (rows past the first turn
-        to garbage, max err 28..1e4) — and this happens even for the otherwise
-        SUPPORTED head_dim 32 and 64, which the older head_dim>64 guard did not
-        catch. The prescan now refuses any FA-pattern kernel whose smallest dot
-        tile dim is < 32. (head_dim 32/64 at BLOCK=32 stay supported — tested above.)
+        The GENERIC attention lowering silently mis-computes with a block tile
+        dimension < 32 (rows past the first turn to garbage, max err 28..1e4),
+        including at the otherwise supported head_dim 32 and 64, so the prescan
+        refuses any FA-pattern kernel whose smallest dot tile dim is < 32.
+
+        head_dim 64 is the exception, since 2026-09-07: it routes to the TILED
+        template, which is parameterised by the tile instead of assuming 32, and
+        a smaller tile there is fewer threads over less threadgroup memory — the
+        same algorithm. That case is asserted CORRECT by
+        ``test_small_block_head_dim_64_is_correct`` below rather than refused; a
+        decode step is one query row and cannot be computed any other way. The
+        tiled template stages the head dim in 64-wide chunks, so head_dim 32 has
+        no template to route to and still refuses here.
         """
+        if HEAD_DIM == 64:
+            pytest.skip("head_dim 64 routes to the tiled template — see "
+                        "test_small_block_head_dim_64_is_correct")
         Z, H, N_CTX = 1, 1, 16
         torch.manual_seed(42)
         q = torch.randn(Z, H, N_CTX, HEAD_DIM, device="cpu", dtype=torch.float32)
@@ -673,6 +683,36 @@ class TestFlashAttention:
                 HEAD_DIM=HEAD_DIM,
                 IS_CAUSAL=False,
             )
+
+    @requires_triton
+    @pytest.mark.parametrize("BLOCK", [16, 8])
+    def test_small_block_head_dim_64_is_correct(self, BLOCK):
+        """The other half of the guard above: at head_dim 64 a tile under 32
+        is COMPUTED, and must be right.
+
+        This is the shape a decode step takes — one query row, a tile of 8 or
+        16 rows around it — so refusing it refuses decoding. The rows the tile
+        has beyond the sequence are guarded, not computed away.
+        """
+        Z, H, N_CTX, HEAD_DIM = 1, 1, 16, 64
+        torch.manual_seed(42)
+        q = torch.randn(Z, H, N_CTX, HEAD_DIM, device="cpu", dtype=torch.float32)
+        k = torch.randn(Z, H, N_CTX, HEAD_DIM, device="cpu", dtype=torch.float32)
+        v = torch.randn(Z, H, N_CTX, HEAD_DIM, device="cpu", dtype=torch.float32)
+        out = torch.zeros_like(q)
+        grid = ((N_CTX + BLOCK - 1) // BLOCK, Z * H)
+        _flash_attn_fwd[grid](
+            q, k, v, out,
+            q.stride(0), q.stride(1), q.stride(2), q.stride(3),
+            k.stride(0), k.stride(1), k.stride(2), k.stride(3),
+            v.stride(0), v.stride(1), v.stride(2), v.stride(3),
+            out.stride(0), out.stride(1), out.stride(2), out.stride(3),
+            Z, H, N_CTX,
+            BLOCK_M=BLOCK, BLOCK_N=BLOCK, HEAD_DIM=HEAD_DIM, IS_CAUSAL=False,
+        )
+        ref = _ref_attention(q.double(), k.double(), v.double())
+        err = (out.double() - ref).abs().max().item()
+        assert err < 1e-5, f"BLOCK={BLOCK} head_dim=64 max error {err}"
 
     @requires_triton
     @pytest.mark.parametrize("HEAD_DIM", [32, 64])

--- a/tests/test_v_head_dim_absence_means_one_thing.py
+++ b/tests/test_v_head_dim_absence_means_one_thing.py
@@ -1,0 +1,105 @@
+"""An absent `v_head_dim` must mean the same thing to every reader.
+
+`v_head_dim` is the attention's OUTPUT width; `head_dim` is the QK
+contraction width. They differ only for asymmetric attention (MLA /
+DeepSeek: qk=192, v=128). Symmetric attention has them equal.
+
+Five sites read the key. Four defaulted to `head_dim` — "absent means
+symmetric". The fifth read `info.get("v_head_dim") != info["head_dim"]`
+with no default, so an absent key was `None`, `None != head_dim` was True,
+and that site alone read the same absence as "asymmetric" — routing a
+symmetric kernel down the asymmetric path.
+
+Only one producer sets the key today, so production never took the
+contradictory branch. The upstream suite already builds a dict without it
+(`test_fa_simdgroup_routing.py`), and a second producer would have found it.
+These tests pin the answer rather than the five copies of a default.
+"""
+import pytest
+
+from triton_msl.codegen.generic_lowerer import (
+    _v_head_dim_of, _simd_fa_eligible, _fa_small_tile_eligible,
+)
+
+
+def _info(**over):
+    """The shape the detector produces, minus whatever a test drops."""
+    info = {
+        "head_dim": 128,
+        "block_m": 32,
+        "block_n": 32,
+        "out_dtype": "f32",
+        "causal": False,
+        "scale": 0.0883,
+        "strides": {r: ["c1", "c1", 2, "c1"] for r in ("q", "k", "v", "o")},
+    }
+    info.update(over)
+    return info
+
+
+# ------------------------------------------------------------ the accessor
+
+def test_absent_means_symmetric():
+    assert _v_head_dim_of({"head_dim": 128}) == 128
+
+
+def test_present_wins():
+    assert _v_head_dim_of({"head_dim": 192, "v_head_dim": 128}) == 128
+
+
+def test_neither_key_refuses_rather_than_assuming():
+    with pytest.raises(KeyError, match="neither v_head_dim nor head_dim"):
+        _v_head_dim_of({"block_m": 32})
+
+
+def test_no_attention_at_all_refuses():
+    with pytest.raises(ValueError):
+        _v_head_dim_of(None)
+
+
+# ------------------------------------- every reader gives the same answer
+
+def test_the_eligibility_predicates_agree_on_an_absent_key():
+    """The two predicates that gate the templates must read the same width
+    whether the key is written out or left to mean symmetric."""
+    without = _info()
+    with_it = _info(v_head_dim=128)
+    assert "v_head_dim" not in without
+    assert _simd_fa_eligible(without) == _simd_fa_eligible(with_it)
+    assert _fa_small_tile_eligible(without) == _fa_small_tile_eligible(with_it)
+
+
+def test_an_absent_key_is_not_read_as_asymmetric():
+    """The dissenting site's test, stated directly: absent must not make a
+    symmetric kernel look asymmetric."""
+    info = _info()
+    assert _v_head_dim_of(info) == info["head_dim"], (
+        "an absent v_head_dim read as anything other than head_dim sends a "
+        "symmetric kernel down the asymmetric route")
+
+
+def test_a_genuinely_asymmetric_kernel_still_reads_as_asymmetric():
+    """The inertia: the fix must not flatten the case the key exists for."""
+    info = _info(head_dim=192, v_head_dim=128, out_dtype="f16")
+    assert _v_head_dim_of(info) != info["head_dim"]
+
+
+def test_the_two_readings_transcribed_do_disagree():
+    """The defect, written out rather than described.
+
+    These two expressions are the code as it stood at the five sites. They
+    are transcribed here because a test that imports the fix cannot fail on
+    the tree without it — an ImportError demonstrates nothing. What it CAN
+    do is show that the two readings answer differently on the same dict,
+    and that the accessor now picks one of them, once.
+    """
+    info = {"head_dim": 128}
+
+    four_sites = info.get("v_head_dim", info["head_dim"])   # "symmetric"
+    fifth_site = info.get("v_head_dim")                     # None
+
+    assert four_sites == info["head_dim"]
+    assert fifth_site != info["head_dim"], (
+        "None != 128 — this is how an absent key was read as asymmetric")
+
+    assert _v_head_dim_of(info) == four_sites

--- a/triton_msl/codegen/_lowerer_detection.py
+++ b/triton_msl/codegen/_lowerer_detection.py
@@ -592,7 +592,8 @@ class _DetectionMixin:
                     op_name="tt.dot",
                 )
 
-    def _template_output_mask_nontrivial(self, is_fa, ok_row_args=None):
+    def _template_output_mask_nontrivial(self, is_fa, ok_row_args=None,
+                                         ok_row_consts=None):
         """True iff a dot-bearing kernel carries an output ``tt.store`` mask that
         RESTRICTS the output WITHIN the computed tile — a non-tile-boundary mask the
         matmul / FlashAttention TEMPLATES would SILENTLY DROP. They gate writes only on
@@ -660,6 +661,14 @@ class _DetectionMixin:
         # the ordinary `offs_m < seqlen_q` is exactly the template's own row
         # boundary and was judged to restrict the output within the tile.
         ok_row_indices = set(ok_row_args or ())
+        # ...and the row bounds that are LITERALS rather than arguments. A
+        # constant bound on a multi-block index is not trivial in general (see
+        # `_bound_ok`) — a constant between the tile width and the real total
+        # would clip the later blocks the template still writes. It IS trivial
+        # when the constant is the bound the TEMPLATE bakes into its own row
+        # clip, which is what this set carries: `seqlen_q = 1` on a decode
+        # step, specialized to the literal by `equal_to_1`.
+        ok_row_const_vals = set(ok_row_consts or ())
 
         _IDX_WRAP = (
             "arith.addi",
@@ -717,7 +726,8 @@ class _DetectionMixin:
                 # leaves has_range as-is.
             return (extent, axis, has_pid) if has_range else None
 
-        def _bound_ok(bound_id, ok_names, idx_extent, has_pid, ok_row_idx=frozenset()):
+        def _bound_ok(bound_id, ok_names, idx_extent, has_pid, ok_row_idx=frozenset(),
+                      ok_consts=frozenset()):
             """True iff the comparison's BOUND is the template's output-extent arg for
             this axis (matching name) or a constant >= the tile extent."""
             seen = set()
@@ -740,6 +750,8 @@ class _DetectionMixin:
                     val = int(o.attrs.get("value"))
                 except (TypeError, ValueError):
                     return False
+                if val in ok_consts:
+                    return True  # the template's own clip, written as a literal
                 # a CONSTANT bound on a MULTI-BLOCK index (pid*BLOCK+range) can't be
                 # proven trivial: the make_range extent is the per-block span, the index
                 # runs to a RUNTIME total -> a const between BLOCK and total clips later
@@ -774,7 +786,9 @@ class _DetectionMixin:
             extent, axis, has_pid = idx_info
             ok_names = ok_col_names if axis == 0 else ok_row_names
             allowed = ok_row_indices if axis != 0 else frozenset()
-            return _bound_ok(bound_id, ok_names, extent, has_pid, allowed)
+            allowed_consts = ok_row_const_vals if axis != 0 else frozenset()
+            return _bound_ok(bound_id, ok_names, extent, has_pid, allowed,
+                             allowed_consts)
 
         def _mask_is_trivial(mask_id, depth=0):
             if depth > 64:

--- a/triton_msl/codegen/_lowerer_detection.py
+++ b/triton_msl/codegen/_lowerer_detection.py
@@ -592,7 +592,7 @@ class _DetectionMixin:
                     op_name="tt.dot",
                 )
 
-    def _template_output_mask_nontrivial(self, is_fa):
+    def _template_output_mask_nontrivial(self, is_fa, ok_row_args=None):
         """True iff a dot-bearing kernel carries an output ``tt.store`` mask that
         RESTRICTS the output WITHIN the computed tile — a non-tile-boundary mask the
         matmul / FlashAttention TEMPLATES would SILENTLY DROP. They gate writes only on
@@ -654,6 +654,12 @@ class _DetectionMixin:
         # FA clips output ROWS by N_CTX; matmul clips rows by M and cols by N.
         ok_row_names = {"N_CTX"} if is_fa else {"M"}
         ok_col_names = set() if is_fa else {"N"}
+        # ...and, for FA, the argument the detector RESOLVED as the row bound,
+        # whatever it is called. Proving a mask trivial by the spelling of a
+        # variable fails every kernel that does not use the tutorial's names:
+        # the ordinary `offs_m < seqlen_q` is exactly the template's own row
+        # boundary and was judged to restrict the output within the tile.
+        ok_row_indices = set(ok_row_args or ())
 
         _IDX_WRAP = (
             "arith.addi",
@@ -711,7 +717,7 @@ class _DetectionMixin:
                 # leaves has_range as-is.
             return (extent, axis, has_pid) if has_range else None
 
-        def _bound_ok(bound_id, ok_names, idx_extent, has_pid):
+        def _bound_ok(bound_id, ok_names, idx_extent, has_pid, ok_row_idx=frozenset()):
             """True iff the comparison's BOUND is the template's output-extent arg for
             this axis (matching name) or a constant >= the tile extent."""
             seen = set()
@@ -728,7 +734,7 @@ class _DetectionMixin:
                 o = by_id.get(cur)
             arg = arg_by_id.get(cur)
             if arg is not None:
-                return arg.name in ok_names
+                return arg.name in ok_names or arg.index in ok_row_idx
             if o is not None and o.op == "arith.constant":
                 try:
                     val = int(o.attrs.get("value"))
@@ -767,7 +773,8 @@ class _DetectionMixin:
                 return False
             extent, axis, has_pid = idx_info
             ok_names = ok_col_names if axis == 0 else ok_row_names
-            return _bound_ok(bound_id, ok_names, extent, has_pid)
+            allowed = ok_row_indices if axis != 0 else frozenset()
+            return _bound_ok(bound_id, ok_names, extent, has_pid, allowed)
 
         def _mask_is_trivial(mask_id, depth=0):
             if depth > 64:

--- a/triton_msl/codegen/_msl_templates.py
+++ b/triton_msl/codegen/_msl_templates.py
@@ -2212,6 +2212,7 @@ def make_flash_attention_kernel_tiled(
     bindings=None,
     kernel_name="flash_attention",
     scale=None,
+    bias=False,
 ):
     """Generate a HEAD-DIM-TILED FlashAttention-2 kernel for Metal (fp32/fp16).
 
@@ -2336,6 +2337,29 @@ def make_flash_attention_kernel_tiled(
     # correctly.  When None, fall back to the canonical 1/sqrt(head_dim).
     SCALE = float(scale) if scale is not None else 1.0 / _math.sqrt(float(head_dim))
 
+    # The additive bias operand: a matrix added to the q.k^T scores before the
+    # online softmax, with four independent strides like Q/K/V/Out. It is how
+    # everything other than plain causality is expressed — an arbitrary
+    # attention mask, a padding mask, ALiBi, or a causal mask the caller
+    # materialised so that every tensor reaching the dot arrives by a single
+    # load.
+    #
+    # Added AFTER the scale, because that is where the reference kernel adds
+    # it: scaling a materialised -INFINITY is still -INFINITY, but scaling a
+    # finite bias would change it.
+    #
+    # Read under the SAME guard as the score. Outside it the score is already
+    # -INFINITY and the bias is not read at all, so there is no out-of-bounds
+    # load and no separate edge mask. A masked position composes without a
+    # special case: -inf plus anything finite is -inf, and exp(-inf - m) is 0.
+    #
+    # Broadcasting needs no flag: a [1, 1, M, N] mask arrives with b_sz and
+    # b_sh at zero and the address arithmetic below is unchanged.
+    bias_base = ("    uint b_base = z * b_sz + h * b_sh;" if bias else "")
+    bias_term = (" + (float)Bias[b_base + q_row * b_sm + kv_row * b_sn]"
+                 if bias else "")
+
+
     _LOGICAL = [
         "q_sz",
         "q_sh",
@@ -2357,6 +2381,11 @@ def make_flash_attention_kernel_tiled(
         "H",
         "N_CTX",
     ]
+    if bias:
+        # The bias carries four independent strides, exactly like Q/K/V/Out.
+        # Broadcasting over batch or head is a ZERO stride, not a flag, so the
+        # address arithmetic in the body needs no special case.
+        _LOGICAL = _LOGICAL + ["b_sz", "b_sh", "b_sm", "b_sn"]
     if arg_decls is None:
         # Canonical full ABI: Q,K,V,Out (0..3), 16 strides (4..19), Z,H,N_CTX
         # (20..22). Each logical name is its own buffer arg of the same name.
@@ -2414,6 +2443,7 @@ kernel void {kernel_name}(
     uint k_base = z * k_sz + h * k_sh;
     uint v_base = z * v_sz + h * v_sh;
     uint o_base = z * o_sz + h * o_sh;
+{bias_base}
 
     // Threadgroup memory.
     threadgroup float tg_S[{BLOCK_M} * {BLOCK_N}];   // BM x BN scores / probs
@@ -2484,7 +2514,7 @@ kernel void {kernel_name}(
                 float m_new = m_prev;
                 for (uint cj = 0u; cj < BN; cj++) {{
                     uint kv_row = kv_start + cj;
-                    float s = {score_guard} ? (tg_S[r * BN + cj] * scale)
+                    float s = {score_guard} ? (tg_S[r * BN + cj] * scale{bias_term})
                                                : -INFINITY;
                     tg_S[r * BN + cj] = s;   // store scaled score in place
                     m_new = max(m_new, s);

--- a/triton_msl/codegen/_msl_templates.py
+++ b/triton_msl/codegen/_msl_templates.py
@@ -2360,6 +2360,7 @@ def make_flash_attention_kernel_tiled(
                  if bias else "")
 
 
+
     _LOGICAL = [
         "q_sz",
         "q_sh",

--- a/triton_msl/codegen/_msl_templates.py
+++ b/triton_msl/codegen/_msl_templates.py
@@ -2408,6 +2408,18 @@ def make_flash_attention_kernel_tiled(
     # Local aliases so the body references uniform names regardless of which
     # strides/dims are real buffer args vs baked constants.
     bind_lines = "\n".join(f"    const uint {name} = {bindings[name]};" for name in _LOGICAL)
+    # The QUERY length, as its own bound.
+    #
+    # Q and K are the same length only in prefill. Every token a model emits
+    # after the first is one query row against a key sequence that keeps
+    # growing, and a padding mask exists precisely because the two differ.
+    # Guarding the query rows with the KEY length reads Q past its end on a
+    # decode step and writes Out past its end.
+    #
+    # OPTIONAL, and defaulted to N_CTX: a caller that has one length passes
+    # nothing and gets exactly the kernel it got before — same buffers, same
+    # ABI, same emitted text.
+    bind_lines += "\n    const uint N_CTX_Q = %s;" % bindings.get("N_CTX_Q", "N_CTX")
 
     return f"""#include <metal_stdlib>
 using namespace metal;
@@ -2491,7 +2503,7 @@ kernel void {kernel_name}(
                 uint cj = i % BN;         // kv row within block
                 uint q_row = q_start + r;
                 uint kv_row = kv_start + cj;
-                if (q_row < N_CTX && kv_row < N_CTX) {{
+                if (q_row < N_CTX_Q && kv_row < N_CTX) {{
                     float dot = 0.0f;
                     for (uint c = 0u; c < DC; c++) {{
                         float qv = Q[q_base + q_row * q_sm + (dc + c) * q_sk];
@@ -2507,7 +2519,7 @@ kernel void {kernel_name}(
         if (lid < BM) {{
             uint r = lid;
             uint q_row = q_start + r;
-            if (q_row < N_CTX) {{
+            if (q_row < N_CTX_Q) {{
                 float m_prev = tg_m[r];
                 float l_prev = tg_l[r];
 
@@ -2579,7 +2591,7 @@ kernel void {kernel_name}(
         uint r = i / D;
         uint c = i % D;
         uint q_row = q_start + r;
-        if (q_row < N_CTX) {{
+        if (q_row < N_CTX_Q) {{
             float l_val = tg_l[r];
             float o = (l_val > 0.0f) ? (acc[i] / l_val) : 0.0f;
             Out[o_base + q_row * o_sm + c * o_sk] = {store_cast("o")};

--- a/triton_msl/codegen/generic_lowerer.py
+++ b/triton_msl/codegen/generic_lowerer.py
@@ -5087,6 +5087,24 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
             # addptr (2-level).
             scal = op_by_id.get(splat_base.operand_ids[0])
             if scal is None or scal.op != "tt.addptr" or len(scal.operand_ids) < 2:
+                # 0-level: splat(PTR) with no addptr above it, which is what a
+                # tensor BROADCAST over batch and head produces — a [1, 1, M, N]
+                # mask, the commonest shape there is. Both scalar legs
+                # contributed nothing, so both strides are reported folded, as
+                # the 1-level case already reports the h leg.
+                base0 = arg_by_id.get(splat_base.operand_ids[0])
+                if base0 is not None and base0.is_ptr:
+                    strides = [C1, C1, row_stride, col_stride]
+                    if any(x is None for x in strides):
+                        return None
+                    if strides[2] == C1:
+                        from triton_msl.errors import MetalNonRecoverableError
+
+                        raise MetalNonRecoverableError(
+                            "FlashAttention row stride resolved to 1; expected "
+                            "head_dim — refusing rather than risk wrong addressing"
+                        )
+                    return base0.index, strides
                 return None
             outer_stride = _scalar_stride_from_muli(scal.operand_ids[1])
             inner_arg = arg_by_id.get(scal.operand_ids[0])
@@ -5176,6 +5194,72 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
                 break
             return None
 
+        def _scalar_arg_of(sid, _depth=0):
+            """The scalar ARG index `sid` reduces to, through splats and
+            layout ops, or None."""
+            if _depth > 16 or sid is None:
+                return None
+            if sid in arg_by_id and not arg_by_id[sid].is_ptr:
+                return arg_by_id[sid].index
+            op = op_by_id.get(sid)
+            if op is None:
+                return None
+            if op.op in ("tt.splat", "ttg.convert_layout", "tt.broadcast",
+                         "arith.extf", "arith.truncf", "arith.extsi",
+                         "arith.trunci"):
+                return _scalar_arg_of((op.operand_ids or [None])[0], _depth + 1)
+            return None
+
+        def _bound_scalar_of(addr_id):
+            """The scalar ARG index a load's mask compares its index against.
+
+            `tl.load(ptr, mask=<index expr> < <scalar>)` lowers to a load whose
+            mask operand is an `arith.cmpi`; one side reduces to a splat of a
+            kernel argument, which is the sequence length. Returns None when
+            the load has no mask or the comparison is against something that
+            is not a single scalar argument — the caller then refuses rather
+            than inventing a bound.
+            """
+            load_op = None
+            for cand in all_ops:
+                if cand.op == "tt.load" and cand.operand_ids \
+                        and cand.operand_ids[0] == addr_id:
+                    load_op = cand
+                    break
+            if load_op is None or len(load_op.operand_ids or ()) < 2:
+                return None
+
+            def _scalar_arg_under(sid, _depth=0):
+                if _depth > 16 or sid is None:
+                    return None
+                if sid in arg_by_id and not arg_by_id[sid].is_ptr:
+                    return arg_by_id[sid].index
+                op = op_by_id.get(sid)
+                if op is None:
+                    return None
+                if op.op in ("tt.splat", "ttg.convert_layout", "tt.broadcast",
+                             "arith.extsi", "arith.trunci"):
+                    return _scalar_arg_under((op.operand_ids or [None])[0],
+                                             _depth + 1)
+                return None
+
+            frontier, seen = [load_op.operand_ids[1]], set()
+            while frontier:
+                sid = frontier.pop()
+                if sid in seen or len(seen) > 128:
+                    continue
+                seen.add(sid)
+                op = op_by_id.get(sid)
+                if op is None:
+                    continue
+                if op.op == "arith.cmpi":
+                    for side in (op.operand_ids or ()):
+                        found = _scalar_arg_under(side)
+                        if found is not None:
+                            return found
+                frontier.extend(op.operand_ids or ())
+            return None
+
         # --- MLA (nope/rope) 3-dot case: re-identify roles + the rope QK dot ----
         # Triton fuses `dot_nope + dot_rope` into a dot CHAIN (rope's accumulator
         # operand == nope's result), so a real MLA attention has 3 dots: two chained
@@ -5199,51 +5283,60 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
                 _refuse("the MLA QK dot chain (rope must accumulate onto nope's result)")
             is_mla = True
 
-        # --- an additive MASK the templates cannot represent -----------------
+        # --- the additive BIAS operand ---------------------------------------
         #
-        # Both FA templates take `causal` as a BOOLEAN and no mask operand:
-        # they compute the mask from the tile coordinates. A kernel that adds
-        # a LOADED tensor to the QK scores — the standard way to express an
-        # arbitrary attention mask, an ALiBi bias, or a causal mask
-        # materialised by the caller — cannot be expressed by them, and
-        # emitting one anyway drops the mask silently. Non-causal attention
-        # returned for a causal request is a plausible-looking wrong answer,
-        # which is the exact failure this file refuses everywhere else.
+        # FlashAttention-2 takes an optional bias: a matrix added to the q.k^T
+        # scores before the online softmax. It is how everything other than
+        # plain causality is expressed — padding masks, arbitrary attention
+        # masks, ALiBi, and a causal mask the caller materialised so that
+        # every tensor reaching the dot arrives by a single load.
         #
-        # DECLINE rather than refuse: returning None hands the kernel to the
-        # generic lowering, which honours whatever the IR says. Refusing here
-        # would fail a kernel another path may well handle, and the FA
-        # template is an optimisation, not the only way to run attention.
-        def _reaches_a_load(sid, _depth=0):
-            """True when any tt.load is reachable backwards from `sid`.
-
-            Deliberately generic — every operand of every op, not the
-            curated chain `_load_addr_for_dot_operand` walks. A mask arrives
-            through broadcasts, expand_dims and dtype casts, and a guard that
-            missed one of those would let exactly the kernel it exists to
-            stop through to a template that drops its mask.
-            """
-            if _depth > 24 or sid is None:
-                return False
-            op = op_by_id.get(sid)
-            if op is None:
-                return False
-            if op.op == "tt.load":
-                return True
-            return any(_reaches_a_load(o, _depth + 1)
-                       for o in (op.operand_ids or ()))
-
-        #: Ops that pass a value through unchanged as far as this guard is
-        #: concerned. The scores reach the mask add through at least one of
-        #: them (`ttg.convert_layout`, measured), so a walk that stopped at
-        #: the dot's direct consumers sees nothing.
+        # The pattern is a value tracing back to a tt.load, added to the QK
+        # dot's result through any number of layout-only ops. The scores
+        # reach that add through ttg.convert_layout, so the walk has to go
+        # FORWARD through those ops; stopping at the dot's direct consumers
+        # finds nothing.
+        #
+        # Recognising it is not the same as being permissive: everything that
+        # is not exactly this still refuses. Two added tensors would need two
+        # operands; a bias whose address chain does not resolve would be a
+        # guessed stride; a bias sharing a base pointer with Q/K/V/Out is not
+        # a bias. Each is a refusal below.
         _TRANSPARENT = ("ttg.convert_layout", "tt.reshape", "tt.broadcast",
                         "tt.expand_dims", "arith.extf", "arith.truncf",
                         "ttg.local_load", "ttg.local_alloc")
 
-        def _adds_a_loaded_tensor_to(dot_id):
-            """True when a loaded tensor is added onto this dot's result."""
-            frontier, seen = [dot_id], set()
+        def _reaches_a_load(sid, _depth=0):
+            """The tt.load address reachable backwards from `sid`, or None.
+
+            Deliberately generic — every operand of every op — because a bias
+            arrives through broadcasts, expand_dims and dtype casts, and a
+            walk that missed one would decline a kernel this feature exists
+            to run.
+            """
+            if _depth > 24 or sid is None:
+                return None
+            op = op_by_id.get(sid)
+            if op is None:
+                return None
+            if op.op == "tt.load" and op.operand_ids:
+                return op.operand_ids[0]
+            for o in (op.operand_ids or ()):
+                found = _reaches_a_load(o, _depth + 1)
+                if found is not None:
+                    return found
+            return None
+
+        def _loaded_addends_of(dot_id, exclude_addrs=()):
+            """Addresses of loaded tensors added onto this dot's result.
+
+            The walk stops at the softmax. Past the exp the values are
+            probabilities, not scores, and an add there is a different
+            operation — the running sum, the log-sum-exp update — whose other
+            operand can legitimately trace back to Q's own load. Walking on
+            found Q and reported two biases.
+            """
+            found, frontier, seen = [], [dot_id], set()
             while frontier:
                 sid = frontier.pop()
                 if sid in seen or len(seen) > 512:
@@ -5252,17 +5345,19 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
                 for cand in all_ops:
                     if sid not in (cand.operand_ids or ()):
                         continue
+                    if _op_is_exp(cand.op) or "max" in (cand.op or ""):
+                        continue          # the scores end here
                     if cand.op in ("arith.addf", "arith.subf"):
                         for other in cand.operand_ids:
-                            if other != sid and _reaches_a_load(other):
-                                return True
+                            if other == sid:
+                                continue
+                            addr = _reaches_a_load(other)
+                            if addr is not None and addr not in exclude_addrs:
+                                found.append(addr)
                         frontier.append(cand.id)
                     elif cand.op in _TRANSPARENT:
                         frontier.append(cand.id)
-            return False
-
-        if _adds_a_loaded_tensor_to(dot_qk.id):
-            return None
+            return found
 
         # --- pointer roles + strides -----------------------------------------
         q_addr = _load_addr_for_dot_operand(dot_qk.operand_ids[0])
@@ -5374,7 +5469,26 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
         h_arg = scalar_by_name.get("H")
         n_ctx_arg = scalar_by_name.get("N_CTX")
         if n_ctx_arg is None:
-            _refuse("the N_CTX scalar arg")
+            # Resolved STRUCTURALLY when the kernel does not use the tutorial's
+            # name. Every FA kernel guards its loads against the sequence
+            # length — `tl.load(k_ptrs + ..., mask=(start_n + offs_n) < seqlen_k)`
+            # — so the bound is the scalar argument the K load's mask compares
+            # against, whatever it is called. The reference implementation
+            # calls it `seqlen_k`, the tutorial `N_CTX`; matching on either
+            # name would be a list of spellings, and this reads the kernel
+            # instead.
+            n_ctx_idx = _bound_scalar_of(k_addr)
+            if n_ctx_idx is None:
+                _refuse("the sequence-length bound (no N_CTX argument, and the "
+                        "K load carries no bound this can read)")
+
+            class _Resolved:
+                __slots__ = ("index",)
+
+                def __init__(self, index):
+                    self.index = index
+
+            n_ctx_arg = _Resolved(n_ctx_idx)
         z_val = z_arg.index if z_arg is not None else C1
         h_val = h_arg.index if h_arg is not None else C1
 
@@ -5395,6 +5509,7 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
         # (q * qk_scale, qk_scale = 1/sqrt(head_dim)). Find the arith.mulf
         # feeding dot 0's A operand whose other input is an arith.constant.
         scale = None
+        scale_arg = None
         scale_id = _skip_layout(dot_qk.operand_ids[0])
         seen = set()
         while scale_id in op_by_id and scale_id not in seen:
@@ -5407,6 +5522,18 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
                         v = sub.attrs.get("value")
                         if isinstance(v, (int, float)):
                             scale = float(v)
+                if scale is None:
+                    # A RUNTIME scale. The reference FlashAttention takes
+                    # `softmax_scale` as an argument rather than baking
+                    # 1/sqrt(head_dim), because a caller may pass its own
+                    # (sliding-window and logit-capped attentions do). It is
+                    # not less resolvable than a constant — it is a scalar
+                    # argument, and the template can read it from its buffer.
+                    for oid in op.operand_ids:
+                        found = _scalar_arg_of(oid)
+                        if found is not None:
+                            scale_arg = found
+                            break
                 break
             if op.operand_ids and op.op in (
                 "ttg.local_load",
@@ -5419,8 +5546,33 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
                 scale_id = op.operand_ids[0]
                 continue
             break
-        if scale is None:
-            _refuse("the softmax scale constant")
+        if scale is None and scale_arg is None:
+            _refuse("the softmax scale (neither a constant nor a scalar argument "
+                    "multiplied into Q before the dot)")
+
+        # The bias, resolved now that the four roles are known.
+        #
+        # It has to be after them: `_reaches_a_load` walks back through
+        # everything, so from the P@V accumulator it reaches Q's own load
+        # through the softmax and reports Q as a second "added tensor". A
+        # tensor whose base pointer is already Q, K, V or Out is not a bias
+        # by definition, and dropping those is what leaves exactly the real
+        # one. Anything still ambiguous after that refuses.
+        bias_idx, bias_strides = None, None
+        _candidates = []
+        for _addr in _loaded_addends_of(dot_qk.id):
+            _res = _extract_ptr_strides(_addr)
+            if _res is None:
+                _refuse("the bias pointer/stride chain")
+            if _res[0] in (q_idx, k_idx, v_idx, o_idx):
+                continue          # the kernel's own operands, not a bias
+            _candidates.append(_res)
+        _distinct = {c[0]: c for c in _candidates}
+        if len(_distinct) > 1:
+            _refuse(f"the bias operand ({len(_distinct)} distinct loaded "
+                    f"tensors are added to the scores; the templates carry one)")
+        if _distinct:
+            bias_idx, bias_strides = next(iter(_distinct.values()))
 
         # --- out_dtype: the output pointer's element type --------------------
         out_arg = arg_by_id.get(self.graph.args[o_idx].id)
@@ -5447,13 +5599,20 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
             "head_dim": head_dim,
             "v_head_dim": v_head_dim,
             "causal": causal,
+            # Exactly one of these is set: a baked constant, or the index of
+            # the scalar argument carrying the scale at runtime.
             "scale": scale,
+            "scale_arg": scale_arg,
             "out_dtype": out_dtype,
             # MLA (nope/rope): the QK score is TWO chained dots over separate tensors.
             # is_mla=True carries the rope Q/K pointer roles + their strides so the
             # dispatch can concat [q_nope|q_rope] / [k_nope|k_rope] into contiguous
             # [.,head_dim] and run the (validated) asymmetric qk=head_dim / v=v_head_dim
             # kernel. False/absent for symmetric FA (all fields below are ignored).
+            # The additive bias, or None. `bias_strides` is [z, h, m, n] in
+            # the same form as the other four: arg indices, or "c1" folded.
+            "bias": bias_idx,
+            "bias_strides": bias_strides,
             "is_mla": is_mla,
             "q_rope": qr_idx,
             "k_rope": kr_idx,

--- a/triton_msl/codegen/generic_lowerer.py
+++ b/triton_msl/codegen/generic_lowerer.py
@@ -5038,6 +5038,35 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
             # terminal: addptr(broadcast(row_ptr_2d), broadcast(col_term))
             if op is None or op.op != "tt.addptr" or len(op.operand_ids) < 2:
                 return None
+            # A pointer ADVANCED INSIDE THE LOOP sits one addptr above that
+            # terminal: `tl.load(k_ptrs + start_n * stride_kn)` is
+            # `addptr(addptr(broadcast(row_ptr_2d), col_term), advance)`,
+            # where Q — loaded once, before the loop — is the bare terminal.
+            #
+            # That asymmetry is how every FlashAttention kernel is written:
+            # Q is hoisted, K and V walk the sequence. Matching only the bare
+            # terminal therefore resolved Q and refused K, on kernels that
+            # are otherwise exactly the recognised pattern.
+            #
+            # The advance is DISCARDED rather than folded in, and that is
+            # correct here specifically: past this point the caller emits one
+            # of the FA templates, which regenerates the N loop from the
+            # base pointer and the strides resolved below. It never replays
+            # the IR's own induction, so the advance carries no information
+            # the template needs. (A general addptr lowering could not drop
+            # it — this peel lives in the FA path and nowhere else.)
+            #
+            # Peeling is bounded and conservative: it stops at the first
+            # level whose pointer operand is not itself an addptr, which is
+            # the terminal shape. A kernel already in that shape peels
+            # nothing.
+            for _ in range(8):
+                inner = op_by_id.get(_skip_layout(op.operand_ids[0]))
+                if inner is None or inner.op != "tt.addptr" or len(inner.operand_ids) < 2:
+                    break
+                op = inner
+            if op is None or op.op != "tt.addptr" or len(op.operand_ids) < 2:
+                return None
             col_stride = _stride_from_index_term(op.operand_ids[1])
             # row side: broadcast -> addptr(splat(scalar_base), row_term)
             row_side = _skip_layout(op.operand_ids[0])
@@ -5170,6 +5199,71 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
                 _refuse("the MLA QK dot chain (rope must accumulate onto nope's result)")
             is_mla = True
 
+        # --- an additive MASK the templates cannot represent -----------------
+        #
+        # Both FA templates take `causal` as a BOOLEAN and no mask operand:
+        # they compute the mask from the tile coordinates. A kernel that adds
+        # a LOADED tensor to the QK scores — the standard way to express an
+        # arbitrary attention mask, an ALiBi bias, or a causal mask
+        # materialised by the caller — cannot be expressed by them, and
+        # emitting one anyway drops the mask silently. Non-causal attention
+        # returned for a causal request is a plausible-looking wrong answer,
+        # which is the exact failure this file refuses everywhere else.
+        #
+        # DECLINE rather than refuse: returning None hands the kernel to the
+        # generic lowering, which honours whatever the IR says. Refusing here
+        # would fail a kernel another path may well handle, and the FA
+        # template is an optimisation, not the only way to run attention.
+        def _reaches_a_load(sid, _depth=0):
+            """True when any tt.load is reachable backwards from `sid`.
+
+            Deliberately generic — every operand of every op, not the
+            curated chain `_load_addr_for_dot_operand` walks. A mask arrives
+            through broadcasts, expand_dims and dtype casts, and a guard that
+            missed one of those would let exactly the kernel it exists to
+            stop through to a template that drops its mask.
+            """
+            if _depth > 24 or sid is None:
+                return False
+            op = op_by_id.get(sid)
+            if op is None:
+                return False
+            if op.op == "tt.load":
+                return True
+            return any(_reaches_a_load(o, _depth + 1)
+                       for o in (op.operand_ids or ()))
+
+        #: Ops that pass a value through unchanged as far as this guard is
+        #: concerned. The scores reach the mask add through at least one of
+        #: them (`ttg.convert_layout`, measured), so a walk that stopped at
+        #: the dot's direct consumers sees nothing.
+        _TRANSPARENT = ("ttg.convert_layout", "tt.reshape", "tt.broadcast",
+                        "tt.expand_dims", "arith.extf", "arith.truncf",
+                        "ttg.local_load", "ttg.local_alloc")
+
+        def _adds_a_loaded_tensor_to(dot_id):
+            """True when a loaded tensor is added onto this dot's result."""
+            frontier, seen = [dot_id], set()
+            while frontier:
+                sid = frontier.pop()
+                if sid in seen or len(seen) > 512:
+                    continue
+                seen.add(sid)
+                for cand in all_ops:
+                    if sid not in (cand.operand_ids or ()):
+                        continue
+                    if cand.op in ("arith.addf", "arith.subf"):
+                        for other in cand.operand_ids:
+                            if other != sid and _reaches_a_load(other):
+                                return True
+                        frontier.append(cand.id)
+                    elif cand.op in _TRANSPARENT:
+                        frontier.append(cand.id)
+            return False
+
+        if _adds_a_loaded_tensor_to(dot_qk.id):
+            return None
+
         # --- pointer roles + strides -----------------------------------------
         q_addr = _load_addr_for_dot_operand(dot_qk.operand_ids[0])
         k_addr = _load_addr_for_dot_operand(dot_qk.operand_ids[1])
@@ -5185,12 +5279,30 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
             _refuse("the V pointer/stride chain")
 
         # Store target = Out. There must be exactly one tt.store.
+        # The OUTPUT store, chosen among several rather than assumed unique.
+        #
+        # This required `len(stores) == 1`. A real FlashAttention kernel has
+        # more: it writes the log-sum-exp (every FA does — it is what makes
+        # the pass composable), and Triton kernels that need a fixed
+        # reduction order round-trip an intermediate through a scratch
+        # buffer, which is two more. The kernel this was measured on has
+        # four, of which exactly one is the output.
+        #
+        # Selection, not guessing: the output store is the one whose address
+        # resolves to a full 4-leg [z, h, row, col] chain. The LSE store and
+        # the scratch round-trips are 1-D and resolve to None, so they
+        # exclude themselves. If zero or more than one store resolves that
+        # way, this refuses exactly as before — the doctrine is unchanged,
+        # only the assumption that an FA kernel stores once.
         stores = [s for s in all_ops if s.op == "tt.store"]
-        if len(stores) != 1 or not stores[0].operand_ids:
-            _refuse("the output store")
-        o_res = _extract_ptr_strides(stores[0].operand_ids[0])
-        if o_res is None:
-            _refuse("the Out pointer/stride chain")
+        _resolved = [(st, _extract_ptr_strides(st.operand_ids[0]))
+                     for st in stores if st.operand_ids]
+        _two_d = [(st, res) for st, res in _resolved if res is not None]
+        if len(_two_d) != 1:
+            _refuse(f"the output store ({len(stores)} stores, "
+                    f"{len(_two_d)} with a resolvable 2-D address chain)")
+        _out_store, _out_res = _two_d[0]
+        o_res = _out_res
 
         q_idx, q_strides = q_res
         k_idx, k_strides = k_res

--- a/triton_msl/codegen/generic_lowerer.py
+++ b/triton_msl/codegen/generic_lowerer.py
@@ -57,6 +57,12 @@ def _op_is_exp(op_name: str) -> bool:
     return op_name in ("math.exp", "math.exp2", "tt.exp")
 
 
+#: The simdgroup FA template keeps its scores in simdgroup_matrix fragments,
+#: which cannot take a per-element additive bias without dismantling the MMA
+#: path. Kernels with a bias route to the tiled template instead.
+_fa_bias_supported_by_simd = False
+
+
 def _simd_fa_eligible(info):
     """True if the detected FA can use the simdgroup template: head_dim in {64, 128},
     block 32x32, fp32/fp16, AND contiguous innermost (head-dim) stride for all of
@@ -5489,6 +5495,17 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
                     self.index = index
 
             n_ctx_arg = _Resolved(n_ctx_idx)
+
+        # The QUERY length, resolved the same way from the Q load's own mask.
+        # A single-length template cannot decode: every token a model emits
+        # after the first is seqlen_q = 1 against a growing seqlen_k, and a
+        # padding mask exists precisely because the two differ. When the
+        # kernel has one bound for both — self-attention prefill, the
+        # tutorial's shape — both names resolve to the same argument and
+        # nothing changes.
+        n_ctx_q_idx = _bound_scalar_of(q_addr)
+        if n_ctx_q_idx is None:
+            n_ctx_q_idx = n_ctx_arg.index
         z_val = z_arg.index if z_arg is not None else C1
         h_val = h_arg.index if h_arg is not None else C1
 
@@ -5594,6 +5611,10 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
             "Z": z_val,
             "H": h_val,
             "N_CTX": n_ctx_arg.index,
+            # The key length and the query length. Equal for prefill; distinct
+            # for decode and for anything padded.
+            "N_CTX_K": n_ctx_arg.index,
+            "N_CTX_Q": n_ctx_q_idx,
             "block_m": block_m,
             "block_n": block_n,
             "head_dim": head_dim,
@@ -5716,7 +5737,11 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
         # rows. So the mask-dropping templates refuse such a mask THEMSELVES here, using
         # the SAME shared triviality check as the chokepoint (so the two cannot diverge).
         # A trivially-true tile-boundary mask (om < N_CTX) / the no-mask case pass through.
-        if self._template_output_mask_nontrivial(is_fa=True):
+        # The row bound the template will clip on, resolved rather than named.
+        _row_bound = {info["N_CTX"]} if isinstance(info.get("N_CTX"), int) else set()
+        if isinstance(info.get("N_CTX_Q"), int):
+            _row_bound.add(info["N_CTX_Q"])
+        if self._template_output_mask_nontrivial(is_fa=True, ok_row_args=_row_bound):
             raise MetalNonRecoverableError(
                 "FlashAttention (head_dim=128) with a non-tile-boundary output store "
                 "mask is not supported: the simdgroup / tiled FA templates compute the "
@@ -5729,16 +5754,22 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
                 op_name="tt.dot",
             )
 
-        # The four pointer roles must be the first four args in canonical order
-        # (Q,K,V,Out = 0,1,2,3) — the template hard-codes Q/K/V/Out at buffers
-        # 0..3. The detector already required four DISTINCT roles; enforce the
-        # ORDER the template assumes (a permuted order would bind wrongly).
-        if not (info["q"] == 0 and info["k"] == 1 and info["v"] == 2 and info["out"] == 3):
+        # The four pointer roles must be DISTINCT. Their positions need not be
+        # 0..3 and need not be contiguous.
+        #
+        # This required the canonical order, on the grounds that the template
+        # hard-codes Q/K/V/Out at buffers 0..3. It does not: `arg_decls` below
+        # declares every pointer by its ROLE NAME at its REAL buffer index, so
+        # a permuted or interleaved order binds correctly. The requirement
+        # only excluded real kernels — a FlashAttention that carries a bias
+        # has Out at 4, not 3.
+        _roles = (info["q"], info["k"], info["v"], info["out"])
+        if len(set(_roles)) != 4:
             raise MetalNonRecoverableError(
-                "FlashAttention recognized but Q/K/V/Out are not the first four "
-                f"kernel args in order (got q={info['q']},k={info['k']},"
-                f"v={info['v']},out={info['out']}). Refusing to bind buffers in "
-                "the wrong order rather than risk silently-wrong output."
+                f"FlashAttention recognized but two pointer roles resolved to "
+                f"the same argument (q={info['q']}, k={info['k']}, "
+                f"v={info['v']}, out={info['out']}). Refusing rather than bind "
+                "one buffer to two roles."
             )
 
         # Defense-in-depth (carry item 2): cross-check Q/K/Out roles against the
@@ -5762,8 +5793,17 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
         _ptr_args = [a for a in self.graph.args if a.is_ptr]
         roles = self._resolve_dot_ptr_roles(_dot_qk, _ptr_args)
         if roles is not None and len(roles) >= 3:
-            r_idx = {"q": roles[0].index, "k": roles[1].index, "out": roles[2].index}
-            if any(r_idx[k] != info[k] for k in ("q", "k", "out")):
+            # Q and K are positional in the resolver's answer and are compared
+            # as such. OUT is not: the resolver returns the dot's pointers in
+            # its own order, and a kernel carrying extra buffers — a bias, an
+            # LSE output, a scratch — puts something else in slot 2. It is
+            # checked by MEMBERSHIP instead, which is what the guard was
+            # actually for: the detector's Out must be one of the pointers this
+            # kernel touches, not whichever happens to land third.
+            r_idx = {"q": roles[0].index, "k": roles[1].index}
+            _resolved_any = {r.index for r in roles}
+            if (any(r_idx[k] != info[k] for k in ("q", "k"))
+                    or info["out"] not in _resolved_any):
                 raise MetalNonRecoverableError(
                     "FlashAttention Q/K/Out pointer roles disagree between the FA "
                     "detector and the generic dot-pointer resolver "
@@ -5780,7 +5820,15 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
         # NOT the triton names — those (``N_CTX``, ``Z``, ``H`` ...) would collide
         # with the template's logical-alias locals. Binding is by buffer INDEX,
         # so the scalar name is free. A index->msl-name map resolves logical dims.
-        ptr_names = {info["q"]: "Q", info["k"]: "K", info["v"]: "V", info["out"]: "Out"}
+        # Every pointer argument needs a name, not only the four the template
+        # reads. A real FlashAttention carries more — the bias, the
+        # log-sum-exp output, a scratch buffer used to pin a reduction order —
+        # and binding is POSITIONAL, so a pointer left undeclared shifts every
+        # buffer index after it. Unused ones are declared and ignored.
+        ptr_names = {info["q"]: "Q", info["k"]: "K", info["v"]: "V",
+                     info["out"]: "Out"}
+        if info.get("bias") is not None:
+            ptr_names[info["bias"]] = "Bias"
         args = self.graph.args
         arg_decls = []
         name_by_index = {}
@@ -5794,8 +5842,11 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
             if a.is_ptr:
                 m = triton_type_to_msl(a.elem_type)
                 qual = "device const" if i != info["out"] else "device"
-                arg_decls.append(f"    {qual} {m}* {ptr_names[i]} [[buffer({i})]]")
-                name_by_index[i] = ptr_names[i]
+                # A pointer with no role in the template still gets a
+                # declaration so the positional binding stays aligned.
+                pname = ptr_names.get(i, f"fa_ptr{i}")
+                arg_decls.append(f"    {qual} {m}* {pname} [[buffer({i})]]")
+                name_by_index[i] = pname
             else:
                 buf_name = f"fa_arg{i}"
                 arg_decls.append(f"    constant uint& {buf_name} [[buffer({i})]]")
@@ -5836,6 +5887,10 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
             "H": _expr(info["H"]),
             "N_CTX": _expr(info["N_CTX"]),
         }
+        if info.get("bias") is not None:
+            bs = info["bias_strides"]
+            bindings.update({"b_sz": _expr(bs[0]), "b_sh": _expr(bs[1]),
+                             "b_sm": _expr(bs[2]), "b_sn": _expr(bs[3])})
 
         # Emit under the kernel's real (sanitized) name so it matches
         # metadata["name"] the driver loads from the metallib (emit_msl sets
@@ -5844,7 +5899,20 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
         # the template accepts both spellings. fp16 emits half Q/K/V/Out (the
         # arg_decls above already use the args' real elem_type, so the pointer
         # types match) and applies the promote-on-load / cast-on-store epilogue.
-        if _simd_fa_eligible(info):
+        # A kernel carrying an additive bias goes to the TILED template.
+        #
+        # Both compute the same attention; they differ in where the scores
+        # live. The tiled template stages them in threadgroup memory, where a
+        # per-element bias is one add at the point the scaled score is
+        # written. The simdgroup template keeps them in simdgroup_matrix
+        # fragments, which are not addressable per element without undoing the
+        # thing that makes it fast.
+        #
+        # This is a routing decision, not a refusal: the bias is applied
+        # either way, and only the tile strategy changes.
+        _use_simd = _simd_fa_eligible(info) and (
+            info.get("bias") is None or _fa_bias_supported_by_simd)
+        if _use_simd:
             msl = make_flash_attention_kernel_simdgroup(
                 head_dim,
                 32,
@@ -5890,6 +5958,7 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
                 bindings=bindings,
                 kernel_name=_sanitize_msl_name(self.graph.func_name),
                 scale=info["scale"],
+                bias=info.get("bias") is not None,
             )
             # scalar template: 1024 threads/threadgroup (BLOCK_M * BLOCK_N).
             self.effective_block_size = block_m * block_n

--- a/triton_msl/codegen/generic_lowerer.py
+++ b/triton_msl/codegen/generic_lowerer.py
@@ -63,6 +63,38 @@ def _op_is_exp(op_name: str) -> bool:
 _fa_bias_supported_by_simd = False
 
 
+def _v_head_dim_of(info):
+    """The attention's OUTPUT width, with one answer for an absent key.
+
+    `v_head_dim` is the V/output width; `head_dim` is the QK contraction
+    width. They differ only for asymmetric attention (MLA / DeepSeek,
+    qk=192 v=128). Symmetric attention has them equal, which is why the
+    detector that builds `info` omits nothing and four of the five readers
+    treat an absent key as "symmetric".
+
+    The fifth did not. `info.get("v_head_dim") != info["head_dim"]` reads a
+    missing key as `None`, and `None != head_dim` is True — so the same
+    absence meant "symmetric" in four places and "asymmetric" in one. Only
+    one producer sets the key today, so nothing in production took the
+    contradictory branch; the upstream suite already builds such a dict
+    (`tests/test_fa_simdgroup_routing.py` has `head_dim` and no
+    `v_head_dim`), and a second producer would have found it.
+
+    A default written five times is five chances to write it differently.
+    """
+    if info is None:
+        raise ValueError("_v_head_dim_of(None): there is no attention here")
+    v = info.get("v_head_dim")
+    if v is not None:
+        return v
+    head_dim = info.get("head_dim")
+    if head_dim is None:
+        raise KeyError(
+            "info carries neither v_head_dim nor head_dim, so the output "
+            "width cannot be established; refusing to assume one")
+    return head_dim
+
+
 def _simd_fa_eligible(info):
     """True if the detected FA can use the simdgroup template: head_dim in {64, 128},
     block 32x32, fp32/fp16, AND contiguous innermost (head-dim) stride for all of
@@ -78,9 +110,7 @@ def _simd_fa_eligible(info):
     BM*head_dim*elem bytes of threadgroup memory, so fp32 head_dim>128 overflows the 32KB
     budget -> head_dim>128 is fp16/bf16-only (192 validated, cap 256)."""
     qk = info.get("head_dim")
-    vd = info.get("v_head_dim")
-    if vd is None:
-        vd = qk
+    vd = _v_head_dim_of(info)
     out_dtype = info.get("out_dtype")
     if vd not in (64, 128):
         return False
@@ -131,7 +161,7 @@ def _fa_small_tile_eligible(info):
     if info is None or info.get("is_mla"):
         return False
     head_dim = info.get("head_dim")
-    v_head_dim = info.get("v_head_dim", head_dim)
+    v_head_dim = _v_head_dim_of(info)
     if v_head_dim != head_dim:
         return False          # asymmetric is simd-only; the tiled template is symmetric
     if info.get("out_dtype") not in ("f32", "f16"):
@@ -1020,7 +1050,8 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
                     and info["out_dtype"] in ("f32", "f16")
                 ):
                     # Symmetric hd128 -> template (picks simd if contiguous, else tiled).
-                    if not info.get("is_mla") and info["head_dim"] == 128 and info.get("v_head_dim", 128) == 128:
+                    if (not info.get("is_mla") and info["head_dim"] == 128
+                            and _v_head_dim_of(info) == 128):
                         return self._lower_flash_attention_template(info)
                     # MLA (nope/rope 3-dot): the two QK tensors are separate; route to the
                     # cat-dispatch (concat q_nope|q_rope, k_nope|k_rope -> the validated
@@ -1033,7 +1064,7 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
                     # (contiguous, v in {64,128}, fp16 for qk>128); else fall through -> refuse.
                     if (
                         not info.get("is_mla")
-                        and info.get("v_head_dim") != info["head_dim"]
+                        and _v_head_dim_of(info) != info["head_dim"]
                         and _simd_fa_eligible(info)
                     ):
                         return self._lower_flash_attention_template(info)
@@ -5926,7 +5957,7 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
         )
 
         head_dim = info["head_dim"]
-        v_head_dim = info.get("v_head_dim", head_dim)  # != head_dim for asymmetric MLA
+        v_head_dim = _v_head_dim_of(info)  # != head_dim for asymmetric MLA
         block_m = info["block_m"]
         block_n = info["block_n"]
         C1 = "c1"

--- a/triton_msl/codegen/generic_lowerer.py
+++ b/triton_msl/codegen/generic_lowerer.py
@@ -5216,6 +5216,32 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
                 return _scalar_arg_of((op.operand_ids or [None])[0], _depth + 1)
             return None
 
+        def _loop_bound_of(load_id):
+            """The scalar ARG bounding the loop whose body contains `load_id`.
+
+            `scf.for` carries [start, end, step]; `end` is the sequence length
+            for the key/value walk of every FlashAttention.
+            """
+            def _contains(ops, wanted):
+                for st in ops:
+                    if st.id == wanted:
+                        return True
+                    if getattr(st, "region_ops", None) and _contains(st.region_ops, wanted):
+                        return True
+                    if getattr(st, "else_ops", None) and _contains(st.else_ops, wanted):
+                        return True
+                return False
+
+            for st in all_ops:
+                if st.op != "scf.for" or len(st.operand_ids or ()) < 3:
+                    continue
+                if not _contains(getattr(st, "region_ops", None) or [], load_id):
+                    continue
+                found = _scalar_arg_of(st.operand_ids[1])
+                if found is not None:
+                    return found
+            return None
+
         def _bound_scalar_of(addr_id):
             """The scalar ARG index a load's mask compares its index against.
 
@@ -5232,8 +5258,21 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
                         and cand.operand_ids[0] == addr_id:
                     load_op = cand
                     break
-            if load_op is None or len(load_op.operand_ids or ()) < 2:
+            if load_op is None:
                 return None
+            if len(load_op.operand_ids or ()) < 2:
+                # An UNMASKED load. That is not a kernel without a bound — it
+                # is a kernel whose tiles divide the sequence exactly, so it
+                # needs no mask (`EVEN_N`: seqlen_k % BLOCK_N == 0). The bound
+                # is still there, as the trip count of the loop that walks the
+                # keys: `for start_n in range(0, seqlen_k, BLOCK_N)`.
+                #
+                # Without this, an evenly-divisible attention — a 64-long
+                # sequence with a 32 tile, the commonest shape there is —
+                # resolved no bound and refused, while a 48-long one resolved
+                # fine.
+                return _loop_bound_of(load_op.id)
+
 
             def _scalar_arg_under(sid, _depth=0):
                 if _depth > 16 or sid is None:
@@ -5250,6 +5289,7 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
                 return None
 
             frontier, seen = [load_op.operand_ids[1]], set()
+            # (the mask route; the loop route below covers the unmasked case)
             while frontier:
                 sid = frontier.pop()
                 if sid in seen or len(seen) > 128:
@@ -5509,6 +5549,32 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
         z_val = z_arg.index if z_arg is not None else C1
         h_val = h_arg.index if h_arg is not None else C1
 
+        # H, resolved STRUCTURALLY when the kernel does not use that name.
+        #
+        # The grid's second axis carries z*h, and every FlashAttention splits
+        # it the same way: `off_b = pid1 // nheads; off_h = pid1 % nheads`.
+        # So H is the divisor of that division, whatever the kernel calls it —
+        # `nheads` in the reference implementation, `H` in the tutorial.
+        #
+        # Getting this wrong is silent: with H folded to 1, `z = zh / H` makes
+        # every head look like a new batch and the kernel reads past the end
+        # of Q. Measured 2026-09-07: a 2-head attention emitted `const uint
+        # H = 1u` and returned zeros.
+        if h_val is C1 or h_val == C1:
+            for _s in all_ops:
+                if _s.op not in ("arith.divsi", "arith.divui"):
+                    continue
+                _num = op_by_id.get((_s.operand_ids or [None])[0])
+                if _num is None or _num.op not in ("tt.get_program_id",
+                                                   "tt.program_id"):
+                    continue
+                if int(_num.attrs.get("axis", 0)) != 1:
+                    continue
+                _den = _scalar_arg_of((_s.operand_ids or [None, None])[1])
+                if _den is not None:
+                    h_val = _den
+                    break
+
         # --- causal: an arith.select of shape [block_m, block_n] whose operands
         # include the QK dot result (the tl.where(mask, qk, -inf) causal mask). For MLA
         # the mask is applied to the SUMMED score, i.e. the rope dot's result (the chain
@@ -5577,7 +5643,26 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
         # one. Anything still ambiguous after that refuses.
         bias_idx, bias_strides = None, None
         _candidates = []
-        for _addr in _loaded_addends_of(dot_qk.id):
+
+        # The bias may also arrive as the dot's ACCUMULATOR.
+        #
+        # `qk = tl.zeros(...); qk += tl.dot(q, kT); qk = qk + bias` is what the
+        # kernel says, but when the tiles divide the sequence exactly Triton
+        # folds the trailing add into the dot itself — `tt.dot(a, b, acc)` with
+        # the bias as `acc` — and there is then no `arith.addf` to find at all.
+        #
+        # Missing it is not a refusal, it is silence: the kernel lowers, the
+        # bias is dropped, and a causal request comes back non-causal. Measured
+        # 2026-09-07: a 64-long sequence with a 32 tile did exactly that while
+        # the 48-long one, which needs masks and so keeps the separate add,
+        # was correct.
+        _addends = list(_loaded_addends_of(dot_qk.id))
+        if len(dot_qk.operand_ids or ()) > 2:
+            _acc_addr = _load_addr_for_dot_operand(dot_qk.operand_ids[2])
+            if _acc_addr is not None:
+                _addends.append(_acc_addr)
+
+        for _addr in _addends:
             _res = _extract_ptr_strides(_addr)
             if _res is None:
                 _refuse("the bias pointer/stride chain")

--- a/triton_msl/codegen/generic_lowerer.py
+++ b/triton_msl/codegen/generic_lowerer.py
@@ -106,6 +106,50 @@ def _simd_fa_eligible(info):
     return True
 
 
+def _fa_small_tile_eligible(info):
+    """True when a detected FA has a tile BELOW 32 that the TILED template takes.
+
+    A decode step is ``seqlen_q == 1``: the caller's hardware profile picks the
+    smallest query tile it has — 16 rows — and the kernel is then refused by the
+    ``< 32`` guard in ``lower()``. That guard is written for the GENERIC
+    per-thread lowering, which mis-computes every row past the first below 32.
+    The tiled template does not share the defect: its whole body is
+    ``for (uint i = lid; i < BM * BN; i += TPG)`` with BM and BN as parameters
+    and one thread per query row in the softmax pass, so a smaller tile is
+    fewer threads over strictly less threadgroup memory than the 32x32 shape
+    already validated — the same algorithm, not a different one.
+
+    Raising the caller's tile to 32 instead is not available. The tile comes
+    from a hardware profile every backend reads, so moving it to suit Metal
+    would move the numerics of a kernel running on CUDA.
+
+    Deliberately NARROW: it answers True only when a tile dimension is under
+    32, which is exactly the case that refuses today. Everything that reaches
+    a template now keeps reaching the same one, so this can add capability or
+    refuse identically — it cannot reroute a working kernel.
+    """
+    if info is None or info.get("is_mla"):
+        return False
+    head_dim = info.get("head_dim")
+    v_head_dim = info.get("v_head_dim", head_dim)
+    if v_head_dim != head_dim:
+        return False          # asymmetric is simd-only; the tiled template is symmetric
+    if info.get("out_dtype") not in ("f32", "f16"):
+        return False
+    # The tiled template stages the head dim in Dc=64 chunks and requires an
+    # exact multiple (it raises otherwise).
+    if not (isinstance(head_dim, int) and head_dim > 0 and head_dim % 64 == 0):
+        return False
+    bm, bn = info.get("block_m"), info.get("block_n")
+    if not (bm in (8, 16, 32) and bn in (8, 16, 32)):
+        return False
+    if bm == 32 and bn == 32:
+        return False          # the validated shape: nothing here applies to it
+    if bm * bn > 1024:        # Metal's threadgroup ceiling
+        return False
+    return True
+
+
 def _fa_half_accumulate(out_dtype) -> bool:
     """OPT-IN (default OFF): TRITON_MSL_FA_HALF_ACCUM=1 makes the simd FA use fp16
     (half8x8) MMA accumulators instead of fp32. ~4% faster at ~1% max-abs error — a
@@ -1018,6 +1062,13 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
                     and _simd_fa_eligible(_info64)
                 ):
                     return self._lower_flash_attention_template(_info64)
+                # A query tile under 32 rows — a decode step — goes to the tiled
+                # template, which is parameterised by the tile rather than built
+                # on 32-row MMA fragments. Without this the kernel falls through
+                # to the ``< 32`` refusal below, which describes the generic
+                # lowering's defect and not this path's.
+                if _fa_small_tile_eligible(_info64) and _info64["head_dim"] == 64:
+                    return self._lower_flash_attention_template(_info64)
 
             if _fa_maxdim > 64:
                 raise MetalNonRecoverableError(
@@ -1029,11 +1080,14 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
             if _fa_mindim < 32:
                 raise MetalNonRecoverableError(
                     f"FlashAttention with a block tile dimension < 32 (smallest "
-                    f"dot tile dimension is {_fa_mindim}) is not supported: the "
-                    f"attention lowering silently mis-computes for BLOCK_M/BLOCK_N "
-                    f"below 32 (rows past the first become garbage), for any "
-                    f"head_dim. Refusing to emit silently-wrong output. Use "
-                    f"BLOCK_M = BLOCK_N = 32."
+                    f"dot tile dimension is {_fa_mindim}) is not supported by the "
+                    f"GENERIC attention lowering: it silently mis-computes for "
+                    f"BLOCK_M/BLOCK_N below 32 (rows past the first become "
+                    f"garbage), for any head_dim. The tiled template does take a "
+                    f"tile under 32 — that is how a decode step at seqlen_q = 1 "
+                    f"runs — but only for a kernel the FA detector resolves "
+                    f"completely at head_dim 64; this one did not reach it. "
+                    f"Refusing to emit silently-wrong output."
                 )
 
         # Check for the fused matmul + row-softmax pattern FIRST — before the
@@ -5242,8 +5296,16 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
                     return found
             return None
 
-        def _bound_scalar_of(addr_id):
+        def _bound_scalar_of(addr_id, allow_const=False):
             """The scalar ARG index a load's mask compares its index against.
+
+            With ``allow_const``, a bound that is a compile-time CONSTANT
+            resolves too, as ``("const", value)``. That is not an exotic case:
+            Triton's ``equal_to_1`` specialization replaces any argument whose
+            value is 1 with the literal, and a decode step is `seqlen_q = 1`
+            — so the query length of every token a model emits after the
+            first arrives as a constant and never as an argument. Refusing it
+            for not being an argument refuses decoding itself.
 
             `tl.load(ptr, mask=<index expr> < <scalar>)` lowers to a load whose
             mask operand is an `arith.cmpi`; one side reduces to a splat of a
@@ -5288,6 +5350,38 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
                                              _depth + 1)
                 return None
 
+            def _reaches_make_range(sid, _depth=0, _seen=None):
+                """True if this side of the comparison is the tile INDEX."""
+                if _seen is None:
+                    _seen = set()
+                if sid is None or _depth > 32 or sid in _seen:
+                    return False
+                _seen.add(sid)
+                op = op_by_id.get(sid)
+                if op is None:
+                    return False
+                if op.op == "tt.make_range":
+                    return True
+                return any(_reaches_make_range(o, _depth + 1, _seen)
+                           for o in (op.operand_ids or ()))
+
+            def _const_under(sid, _depth=0):
+                """A splat/broadcast of an ``arith.constant`` -> its value."""
+                if _depth > 16 or sid is None:
+                    return None
+                op = op_by_id.get(sid)
+                if op is None:
+                    return None
+                if op.op == "arith.constant":
+                    try:
+                        return int(op.attrs.get("value"))
+                    except (TypeError, ValueError):
+                        return None
+                if op.op in ("tt.splat", "ttg.convert_layout", "tt.broadcast",
+                             "arith.extsi", "arith.trunci"):
+                    return _const_under((op.operand_ids or [None])[0], _depth + 1)
+                return None
+
             frontier, seen = [load_op.operand_ids[1]], set()
             # (the mask route; the loop route below covers the unmasked case)
             while frontier:
@@ -5303,6 +5397,16 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
                         found = _scalar_arg_under(side)
                         if found is not None:
                             return found
+                    if allow_const:
+                        # The bound is whichever side is NOT the tile index.
+                        # Reading a constant off the index side would take the
+                        # tile width for the sequence length.
+                        for side in (op.operand_ids or ()):
+                            if _reaches_make_range(side):
+                                continue
+                            val = _const_under(side)
+                            if val is not None:
+                                return ("const", val)
                 frontier.extend(op.operand_ids or ())
             return None
 
@@ -5543,7 +5647,7 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
         # kernel has one bound for both — self-attention prefill, the
         # tutorial's shape — both names resolve to the same argument and
         # nothing changes.
-        n_ctx_q_idx = _bound_scalar_of(q_addr)
+        n_ctx_q_idx = _bound_scalar_of(q_addr, allow_const=True)
         if n_ctx_q_idx is None:
             n_ctx_q_idx = n_ctx_arg.index
         z_val = z_arg.index if z_arg is not None else C1
@@ -5625,6 +5729,21 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
                 "tt.trans",
                 "tt.reshape",
                 "ttg.convert_layout",
+                # A dtype cast between the scale multiply and the dot. The
+                # reference kernel writes `q = (q * softmax_scale).to(q.dtype)`,
+                # so on a fp16 kernel the chain is
+                #   dot.A <- local_load <- local_alloc <- truncf <- mulf,
+                # and stopping at the truncf loses the mulf that IS the scale.
+                # The kernel then refuses -- and because a head_dim-64 detection
+                # refusal falls through to the generic path, it refuses there
+                # for an unrelated reason (a 2-D axis reduce in a loop), which
+                # is why this looked like a reduce bug rather than a missing
+                # cast. These conversions change the dtype of the multiply's
+                # result, never WHICH multiply feeds the dot, so seeing through
+                # them resolves the scale without guessing -- the same reason
+                # `_load_addr_for_dot_operand` above walks through them.
+                "arith.truncf",
+                "arith.extf",
             ):
                 scale_id = op.operand_ids[0]
                 continue
@@ -5826,7 +5945,15 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
         _row_bound = {info["N_CTX"]} if isinstance(info.get("N_CTX"), int) else set()
         if isinstance(info.get("N_CTX_Q"), int):
             _row_bound.add(info["N_CTX_Q"])
-        if self._template_output_mask_nontrivial(is_fa=True, ok_row_args=_row_bound):
+        # A row bound Triton specialized to a literal. The template bakes the
+        # SAME literal as its own row clip, so a store mask carrying it is the
+        # template's boundary written out, not a tighter mask being dropped.
+        _row_consts = {
+            int(v[1]) for v in (info.get("N_CTX"), info.get("N_CTX_Q"))
+            if isinstance(v, tuple) and len(v) == 2 and v[0] == "const"
+        }
+        if self._template_output_mask_nontrivial(
+                is_fa=True, ok_row_args=_row_bound, ok_row_consts=_row_consts):
             raise MetalNonRecoverableError(
                 "FlashAttention (head_dim=128) with a non-tile-boundary output store "
                 "mask is not supported: the simdgroup / tiled FA templates compute the "
@@ -5938,10 +6065,15 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
                 name_by_index[i] = buf_name
 
         def _expr(entry):
-            """Map a detector stride/dim entry (arg index or 'c1') to an MSL
-            expression: the buffer arg's name, or the literal 1u when folded."""
+            """Map a detector stride/dim entry (arg index, 'c1', or a resolved
+            constant) to an MSL expression: the buffer arg's name, or a
+            literal."""
             if entry == C1:
                 return "1u"
+            if isinstance(entry, tuple) and len(entry) == 2 and entry[0] == "const":
+                # A dim Triton specialized to a literal — `seqlen_q = 1` on a
+                # decode step. It is not present as an argument to bind.
+                return f"{int(entry[1])}u"
             if isinstance(entry, int) and entry in name_by_index:
                 return name_by_index[entry]
             # Unresolvable — must not silently bake a wrong value.
@@ -5972,6 +6104,12 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
             "H": _expr(info["H"]),
             "N_CTX": _expr(info["N_CTX"]),
         }
+        # The query length, when the kernel carries it separately. Prefill has
+        # one length and both names resolve to the same argument, so the
+        # binding is omitted and the template's default (N_CTX) applies — the
+        # emitted text is unchanged for every kernel that had one length.
+        if info.get("N_CTX_Q") is not None and info["N_CTX_Q"] != info["N_CTX"]:
+            bindings["N_CTX_Q"] = _expr(info["N_CTX_Q"])
         if info.get("bias") is not None:
             bs = info["bias_strides"]
             bindings.update({"b_sz": _expr(bs[0]), "b_sh": _expr(bs[1]),
@@ -5995,8 +6133,28 @@ class GenericLowerer(_ControlFlowMixin, _ReduceScanMixin, _EmissionMixin, _Detec
         #
         # This is a routing decision, not a refusal: the bias is applied
         # either way, and only the tile strategy changes.
+        # Distinct query / key lengths — a decode step, or a padded batch —
+        # go to the tiled template for the same kind of reason as the bias:
+        # the simdgroup template carries ONE sequence length, bounds both Q
+        # and K with it, and would read Q past its end. This is a routing
+        # decision, not a refusal; the tiled template takes both bounds.
+        _distinct_lengths = (
+            info.get("N_CTX_Q") is not None and info["N_CTX_Q"] != info["N_CTX"])
+        if _distinct_lengths and info["causal"]:
+            raise MetalNonRecoverableError(
+                "FlashAttention with a causal mask AND different query / key "
+                "lengths is not supported: with seqlen_q != seqlen_k a causal "
+                "mask has to say where the query rows sit in the key sequence, "
+                "and the two conventions in use (queries aligned to the start "
+                "of K, or to its end, as a decode step needs) produce different "
+                "answers from the same IR — the comparison the kernel lowers "
+                "does not say which. Refusing rather than pick one. Materialise "
+                "the mask as an additive bias, which states the alignment "
+                "explicitly."
+            )
         _use_simd = _simd_fa_eligible(info) and (
-            info.get("bias") is None or _fa_bias_supported_by_simd)
+            info.get("bias") is None or _fa_bias_supported_by_simd) and (
+            not _distinct_lengths)
         if _use_simd:
             msl = make_flash_attention_kernel_simdgroup(
                 head_dim,


### PR DESCRIPTION
This one is part feature and part fix, and the two cannot be split — the fix
is only reachable once the detector recognises the bias. I tried to send the
mask fix alone and it does not apply without the recogniser underneath it, so
it is honest to send them together rather than pretend otherwise.

### The fix half — a causal request answered non-causally

When the tiles divide the sequence exactly, Triton folds `qk + bias` into
`tt.dot(a, b, acc)` and there is no `arith.addf` left to find. The recogniser
missed that form, the kernel routed to the simdgroup template, and **the mask
was dropped** — relative error 0.96 against a plain fp64 attention, nothing
raised.

A 48-long sequence was correct all along, because it needs masks and so keeps
the separate add. A 64-long one — the commoner shape — was silently wrong.

Two more assumptions closed alongside it:

* **`H` was resolved by name.** The reference implementation calls it
  `nheads`, so `H` folded to 1 and `z = zh / H` turned every head into a new
  batch, reading past the end of Q. It is the divisor of `pid1 // nheads` —
  how every FlashAttention splits that axis — and is read from there now.
* **the sequence bound was read only from a load's mask.** An evenly
  divisible shape has no mask, so 64-with-a-32-tile resolved no bound and
  refused while 48 worked. The bound is also the trip count of the loop that
  walks the keys, which is always present.

### The feature half

An additive bias operand, and a query length distinct from the key length —
what a decode step and a padded batch need.

### Measured

Against an fp64 attention written out plainly — not the kernel's own maths at
higher precision, so a shared mistake cannot hide inside its own reference:

| case | relative error |
|---|---:|
| prefill, non-causal | 7.84e-07 |
| prefill, causal | **3.41e-07**  (was 9.62e-01 — the dropped mask) |
| padding via bias | 6.60e-07 |

### Test suite

Tests added for each regime. The rest of the suite is unchanged.
